### PR TITLE
fix the icc register missing definition

### DIFF
--- a/src/arch/armv8/aarch64/start.S
+++ b/src/arch/armv8/aarch64/start.S
@@ -54,7 +54,7 @@ _start:
     msr vtcr_el2, x1
 #if GIC_VERSION == GICV3
     mov x1, 0x9
-    msr icc_sre_el2, x1
+    msr ICC_SRE_EL2, x1
 #endif
 
 #ifdef MPU


### PR DESCRIPTION
Why: the icc_sre_el2 register belongs to gic icc registers, which GNU AS is not aware of so it needs to be replaced by its op0,op1,CRn,CRm,op2 encoding, but currently there is compiling error. We find this definition in armv8/inc/sysregs.h but with Uppercase How: needs to use in aarch64/inc/sysregs.h, and change here with Uppercase


Signed-off-by: JianlongCao <caojianlong@outlook.com>