### PR TITLE
fix(mpu): open mpu device region before and/or after image

### DIFF
--- a/src/arch/armv8/aarch32/start.S
+++ b/src/arch/armv8/aarch32/start.S
@@ -68,18 +68,47 @@ entry_el1:
     // Set MPU region for cacheability and shareability
     mov r4, #0
     mcr p15, 0, r4, c6, c2, 1  // prselr
+    ldr r4, =(PLAT_MEM_BASE)
+    and r4, r4, #PRBAR_BASE_MSK
+    orr r4, r4, #(PRBAR_SH_IS | PRBAR_AP_RW_ALL)
+    mcr p15, 0, r4, c6, c3, 0  // prbar
+    ldr r4, =(PLAT_MEM_BASE + PLAT_MEM_SIZE - 1)
+    and r4, r4, #PRLAR_LIMIT_MSK
+    orr r4, r4, #(PRLAR_ATTR(1) | PRLAR_EN)
+    mcr p15, 0, r4, c6, c3, 1  // prlar
+
+    ldr r4, =(PLAT_MEM_BASE)
+    cmp r4, #0
+    blne devices_before_img
+    ldr r5, =(PLAT_MEM_BASE + PLAT_MEM_SIZE)
+    cmp r5, #0xffffffff
+    bne devices_after_img
+    b 1f
+
+    devices_before_img:
+    mov r4, #1
+    mcr p15, 0, r4, c6, c2, 1  // prselr
     mov r4, #(PRBAR_BASE(0) | PRBAR_SH_IS | PRBAR_AP_RW_ALL)
     mcr p15, 0, r4, c6, c3, 0  // prbar
-    mov r4, #(PRLAR_LIMIT(0x7fffffffUL) | PRLAR_ATTR(1) | PRLAR_EN)
+    ldr r4, =(PLAT_MEM_BASE - 1)
+    and r4, r4, #PRLAR_LIMIT_MSK
+    orr r4, r4, #(PRLAR_ATTR(2) | PRLAR_EN)
     mcr p15, 0, r4, c6, c3, 1  // prlar
 
     mov r4, #1
+    bx lr
+
+    devices_after_img:
+    add r4, r4, #1
     mcr p15, 0, r4, c6, c2, 1  // prselr
-    mov r4, #(PRBAR_BASE(0x80000000UL) | PRBAR_SH_IS | PRBAR_AP_RW_ALL)
+    ldr r4, =(PLAT_MEM_BASE + PLAT_MEM_SIZE)
+    and r4, r4, #PRBAR_BASE_MSK
+    orr r4, r4, #(PRBAR_SH_IS | PRBAR_AP_RW_ALL)
     mcr p15, 0, r4, c6, c3, 0  // prbar
     mov r4, #(PRLAR_LIMIT(0xffffffffUL) | PRLAR_ATTR(2) | PRLAR_EN)
     mcr p15, 0, r4, c6, c3, 1  // prlar
 
+    1:
     dsb
     isb
 


### PR DESCRIPTION
In some platforms (with MPU) the devices can be before and/or after the image, so the MPU regions must be flexible to cover all those devices.
This PR allows the starting code to create a region for the code and other(s) to the rest of the memory as a device region(s).

Signed-off-by: Afonso Santos afomms@gmail.com