### PR TITLE
fix(riscv/irq): set intp priority only if intp ID is a plic intp

### DIFF
--- a/src/arch/riscv/irq.c
+++ b/src/arch/riscv/irq.c
@@ -5,7 +5,7 @@
 #include <sbi.h>
 
 void irq_enable(unsigned id) {
-    if(id < 1024) {
+    if(id < PLIC_MAX_INTERRUPTS) {
         plic_enable_interrupt(get_cpuid(), id, true);
     } else if (id == TIMER_IRQ_ID) {
         csrs_sie_set(SIE_STIE);
@@ -15,7 +15,9 @@ void irq_enable(unsigned id) {
 }
 
 void irq_set_prio(unsigned id, unsigned prio) {
-    plic_set_prio(id, prio);
+    if(id < PLIC_MAX_INTERRUPTS) {
+        plic_set_prio(id, prio);
+    }
 }
 
 void irq_send_ipi(unsigned long target_cpu_mask) {


### PR DESCRIPTION
This PR fixes the RISC-V irq_set_prio function. Currently, this function does not check if the interrupt is a PLIC interrupt. This means that for IPI and timer interrupts (IDs 1025 and 1029 - not PLIC interrupts) the code also tries to set the priority of these interrupts.