### PR TITLE
FIX: PL011 UART's driver configuration for RPi4

### DIFF
--- a/src/drivers/pl011_uart/inc/pl011_uart.h
+++ b/src/drivers/pl011_uart/inc/pl011_uart.h
@@ -18,8 +18,13 @@
 #ifndef __PL011_UART_H_
 #define __PL011_UART_H_
 
-#include <core.h>
+/* #include <core.h> */
 #include <plat.h>
+#include <stdint.h>
+
+#ifndef PL011_PAGE_OFFSET
+#define PL011_PAGE_OFFSET (0x000) /**< offset in range of 0-0xFFF */
+#endif
 
 /* UART Base Address (PL011) */
 
@@ -194,22 +199,26 @@
 
 typedef struct
 {
-   volatile uint32_t data;                // UART Data Register
-   volatile uint32_t status_error;        // UART Receive Status Register/Error Clear Register
-   const uint32_t reserved1[4];           	// Reserved: 4(0x4) bytes
-   volatile uint32_t flag;                // UART Flag Register
-   const uint32_t reserved2[1];            	// Reserved: 1(0x1) bytes
-   volatile uint32_t lp_counter;          // UART Low-power Counter Register
-   volatile uint32_t integer_br;          // UART Integer Baud Rate Register
-   volatile uint32_t fractional_br;       // UART Fractional Baud Rate Register
-   volatile uint32_t line_control;        // UART Line Control Register
-   volatile uint32_t control;             // UART Control Register
-   volatile uint32_t isr_fifo_level_sel;  // UART Interrupt FIFO level Select Register
-   volatile uint32_t isr_mask;            // UART Interrupt Mask Set/Clear Register
-   volatile uint32_t raw_isr_status;      // UART Raw Interrupt Status Register
-   volatile uint32_t masked_isr_status;   // UART Masked Interrupt Status Register
-   volatile uint32_t isr_clear;           // UART Interrupt Clear Register
-   volatile uint32_t DMA_control;         // UART DMA control Register
+  const uint8_t offset[PL011_PAGE_OFFSET];
+  volatile uint32_t data;               // UART Data Register
+  volatile uint32_t status_error;       // UART Receive Status Register/Error Clear
+  // Register
+  const uint32_t reserved1[4];          // Reserved: 4(0x4) bytes
+  volatile uint32_t flag;               // UART Flag Register
+  const uint32_t reserved2[1];          // Reserved: 1(0x1) bytes
+  volatile uint32_t lp_counter;         // UART Low-power Counter Register
+  volatile uint32_t integer_br;         // UART Integer Baud Rate Register
+  volatile uint32_t fractional_br;      // UART Fractional Baud Rate Register
+  volatile uint32_t line_control;       // UART Line Control Register
+  volatile uint32_t control;            // UART Control Register
+  volatile uint32_t isr_fifo_level_sel; // UART Interrupt FIFO level Select
+  // Register
+  volatile uint32_t isr_mask;           // UART Interrupt Mask Set/Clear Register
+  volatile uint32_t raw_isr_status;     // UART Raw Interrupt Status Register
+  volatile uint32_t masked_isr_status;  // UART Masked Interrupt Status
+  // Register
+  volatile uint32_t isr_clear;          // UART Interrupt Clear Register
+  volatile uint32_t DMA_control;        // UART DMA control Register
 } Pl011_Uart;
 
 /** Public PL011 UART interfaces */

--- a/src/drivers/pl011_uart/inc/pl011_uart.h
+++ b/src/drivers/pl011_uart/inc/pl011_uart.h
@@ -19,6 +19,7 @@
 #define __PL011_UART_H_
 
 #include <core.h>
+#include <plat.h>
 
 /* UART Base Address (PL011) */
 
@@ -40,7 +41,10 @@
 
 #define NUM_UART                 6
 
-#define UART_CLK                 19200000
+#ifndef UART_CLK
+#define UART_CLK                19200000
+#endif
+#define UART_BAUD_RATE           115200
 #define UART_BAUD_RATE           115200
 
 /* UART Data Register */

--- a/src/platform/rpi4/inc/plat.h
+++ b/src/platform/rpi4/inc/plat.h
@@ -10,4 +10,6 @@
 #define PLAT_UART_ADDR (0xfe215000)
 #define UART_IRQ_ID (125)
 
+#define UART_CLK                 48000000
+
 #endif

--- a/src/platform/rpi4/inc/plat.h
+++ b/src/platform/rpi4/inc/plat.h
@@ -7,9 +7,10 @@
 #define PLAT_GICD_BASE_ADDR (0xff841000)
 #define PLAT_GICC_BASE_ADDR (0xff842000)
 
-#define PLAT_UART_ADDR (0xfe215000)
-#define UART_IRQ_ID (125)
+#define UART_CLK 48000000
+#define PL011_PAGE_OFFSET (0xa00) /**< UART5 offset for page alignment */
 
-#define UART_CLK                 48000000
+#define PLAT_UART_ADDR (0xfe201000)
+#define UART_IRQ_ID (125)
 
 #endif

--- a/src/platform/rpi4/plat.mk
+++ b/src/platform/rpi4/plat.mk
@@ -1,3 +1,3 @@
 ARCH:=armv8
 GIC_VERSION:=GICV2
-drivers:=8250_uart
+drivers:=pl011_uart

--- a/src/platform/rpi4/rpi4.c
+++ b/src/platform/rpi4/rpi4.c
@@ -1,32 +1,34 @@
 #include <plat.h>
-#include <8250_uart.h>
+#include <pl011_uart.h>
 
-#define VIRT_UART16550_ADDR		    (UART_ADDR + 0x40)
+Pl011_Uart *uart  = (void*) PLAT_UART_ADDR;
 
-#define VIRT_UART_BAUDRATE		    115200
-#define VIRT_UART_FREQ		        3000000
 
-void uart_init(){
+void uart_init(void)
+{
+    pl011_uart_init(uart);
+    pl011_uart_enable(uart);
 
-    uart8250_init(VIRT_UART16550_ADDR, VIRT_UART_FREQ, VIRT_UART_BAUDRATE, 0, 4);
+    return;
 }
 
 void uart_putc(char c)
 {
-    uart8250_putc(c);
+    pl011_uart_putc(uart, c);
 }
 
 char uart_getchar(void)
 {
-    return uart8250_getc();
+    return pl011_uart_getc(uart);
 }
 
-void uart_enable_rxirq()
-{
-    uart8250_enable_rx_int();
+void uart_enable_rxirq(){
+
 }
 
-void uart_clear_rxirq()
-{
-    uart8250_interrupt_handler(); 
+void uart_clear_rxirq(){
+    while(!(uart->flag & UART_FR_RXFE)) {
+        volatile char c = uart->data;
+    }
+    uart->isr_clear = 0xffff;
 }


### PR DESCRIPTION
- UART_CLK must be overridable and defined by the platform's user (plat.h): in RPi4 PL011 run at 48 MHz