### PR TITLE
feat(rh850-u2a16): Add support for RH850-U2A16

### DIFF
--- a/src/arch/rh850/arch.mk
+++ b/src/arch/rh850/arch.mk
@@ -1,0 +1,8 @@
+CROSS_COMPILE ?= v850-elf-
+
+ARCH_GENERIC_FLAGS = -mv850e3v5 -mrh850-abi -m8byte-align -msoft-float
+ARCH_ASFLAGS = -mv850e3v5 -mrh850-abi -m8byte-align
+ARCH_CFLAGS =
+ARCH_CPPFLAGS =
+ARCH_LDFLAGS =
+platform_debug_flags:= -gdwarf-4

--- a/src/arch/rh850/exceptions.S
+++ b/src/arch/rh850/exceptions.S
@@ -1,0 +1,199 @@
+.section ".text", "ax"
+.extern _start
+
+.balign	0x200
+.global _vector_table
+_vector_table:
+	jr	_start // RESET
+
+	.balign	16
+	syncp
+	jr	_handle_exception // SYSERR  Guest
+
+	.balign	16
+	jr	_handle_exception // (R.F.U)
+
+	.balign	16
+	jr	_handle_exception // FETRAP  Guest?
+
+	.balign	16
+	jr	_handle_exception // TRAP0  Guest?
+
+	.balign	16
+	jr	_handle_exception // TRAP1  Guest?
+
+	.balign	16
+	jr	_handle_exception // RIE
+
+	.balign	16
+	syncp
+	jr	_handle_exception // FPP/FPI
+
+	.balign	16
+	jr	_handle_exception // UCPOP
+
+	.balign	16
+	jr	_handle_exception // MIP/MDP  Guest
+
+	.balign	16
+	jr	_handle_exception // RIE
+
+	.balign	16
+	jr	_handle_exception // PIE
+
+	.balign	16
+	jr	_handle_exception // MAE
+
+	.balign	16
+	jr	_handle_exception // UCPOP
+
+	.balign	16
+	syncp
+	jr	_handle_exception // FENMI
+
+	.balign	16
+	syncp
+	jr	_handle_exception // FEINT
+
+	// only used with direct vector method
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority0)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority1)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority2)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority3)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority4)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority5)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority6)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority7)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority8)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority9)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority10)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority11)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority12)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority13)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority14)
+
+	.balign	16
+	syncp
+	jr	_Interrupt_EI // INTn(priority15)
+
+.section ".text", "ax"
+.balign	0x2
+
+select_xxret:
+	stsr 5, r31, 0
+	andi 0x80, r31, r31 // PSW.NP
+	cmp r0, r31
+	be ei_ret
+	stsr 28, r31, 0
+  	feret
+ei_ret:
+	stsr 28, r31, 0
+	eiret
+
+.macro SAVE_REGS
+    addi 124, r0, r20
+    sub r20, sp
+
+    st.dw r0,    0[sp]
+    st.dw r2,    8[sp]
+    st.dw r4,   16[sp]
+    st.dw r6,   24[sp]
+    st.dw r8,   32[sp]
+    st.dw r10,  40[sp]
+    st.dw r12,  48[sp]
+    st.dw r14,  56[sp]
+    st.dw r16,  64[sp]
+    st.dw r18,  72[sp]
+    st.dw r20,  80[sp]
+    st.dw r22,  88[sp]
+    st.dw r24,  96[sp]
+    st.dw r26, 104[sp]
+    st.dw r28, 112[sp]
+    st.dw r30, 120[sp]
+.endm
+
+.macro RESTORE_REGS
+    ld.dw   0[sp], r0
+    ld.w    8[sp], r2 // dont restore r3 which is the sp
+    ld.dw  16[sp], r4
+    ld.dw  24[sp], r6
+    ld.dw  32[sp], r8
+    ld.dw  40[sp], r10
+    ld.dw  48[sp], r12
+    ld.dw  56[sp], r14
+    ld.dw  64[sp], r16
+    ld.dw  72[sp], r18
+    ld.dw  80[sp], r20
+    ld.dw  88[sp], r22
+    ld.dw  96[sp], r24
+    ld.dw 104[sp], r26
+    ld.dw 112[sp], r28
+    ld.dw 120[sp], r30
+
+    addi 124, r0, r20
+    add r20, sp
+.endm
+
+.extern _irq_handle
+
+_handle_exception:
+	br _handle_exception
+
+_Interrupt_EI:
+
+	SAVE_REGS
+
+	// copy int_id to r6
+	stsr 13, r6, 0 // get int cause from EEIC
+	mov 0x7FF, r20
+	and r20, r6 // mask EIINT source
+
+  	jarl _irq_handle, lp
+
+  	RESTORE_REGS
+
+  	eiret

--- a/src/arch/rh850/inc/arch/irq.h
+++ b/src/arch/rh850/inc/arch/irq.h
@@ -1,0 +1,16 @@
+#ifndef ARCH_IRQ_H
+#define ARCH_IRQ_H
+
+#include <intc.h>
+
+#define IPI_IRQ_ID (0UL)
+
+
+#define IRQ_NUM (ARCH_MAX_INTERRUPTS)
+#define IRQ_MAX_PRIO (0x1)
+
+#define UART_IRQ_PRIO   IRQ_MAX_PRIO
+#define TIMER_IRQ_PRIO  IRQ_MAX_PRIO
+#define IPI_IRQ_PRIO    IRQ_MAX_PRIO
+
+#endif /* ARCH_IRQ_H */

--- a/src/arch/rh850/inc/arch/timer.h
+++ b/src/arch/rh850/inc/arch/timer.h
@@ -1,0 +1,11 @@
+#ifndef ARCH_TIMER_H
+#define ARCH_TIMER_H
+
+#include <core.h>
+#include <plat.h>
+
+void timer_enable();
+uint64_t timer_get();
+void timer_set(uint64_t n);
+
+#endif /* ARCH_TIMER_H */

--- a/src/arch/rh850/inc/cpu.h
+++ b/src/arch/rh850/inc/cpu.h
@@ -1,0 +1,15 @@
+#ifndef CPU_H
+#define CPU_H
+
+#include <core.h>
+#include <srs.h>
+
+static inline unsigned long get_cpuid(){
+    return srs_peid_read();
+}
+
+static inline bool cpu_is_master(){
+    return get_cpuid() == 0;
+}
+
+#endif

--- a/src/arch/rh850/inc/fences.h
+++ b/src/arch/rh850/inc/fences.h
@@ -1,0 +1,61 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __FENCES_ARCH_H__
+#define __FENCES_ARCH_H__
+
+#include <core.h>
+
+static inline void syncp(void)
+{
+    __asm__ volatile("syncp" ::: "memory");
+}
+
+static inline void syncm(void)
+{
+    __asm__ volatile("syncm" ::: "memory");
+}
+
+static inline void synci(void)
+{
+    __asm__ volatile("synci" ::: "memory");
+}
+
+static inline void synce(void)
+{
+    __asm__ volatile("synce" ::: "memory");
+}
+
+static inline void fence_ord_write(void)
+{
+    synci();
+}
+
+static inline void fence_ord_read(void)
+{
+    synci();
+}
+
+static inline void fence_ord(void)
+{
+    synci();
+}
+
+static inline void fence_sync_write(void)
+{
+    synci();
+}
+
+static inline void fence_sync_read(void)
+{
+    synci();
+}
+
+static inline void fence_sync(void)
+{
+    synci();
+}
+
+#endif /* __FENCES_ARCH_H__ */

--- a/src/arch/rh850/inc/intc.h
+++ b/src/arch/rh850/inc/intc.h
@@ -1,0 +1,78 @@
+#ifndef INTC_H
+#define INTC_H
+
+#include <core.h>
+
+#define ARCH_MAX_CPUS   8
+#define ARCH_MAX_INTERRUPTS    2048
+
+#define PRIVATE_IRQS_NUM 32
+
+struct intc1 {
+    uint16_t EIC[PRIVATE_IRQS_NUM];     /* 0x000 - 0x040 */
+    uint8_t  PAD0[176];                 /* 0x040 - 0x0F0 */
+    uint32_t IMR;                       /* 0x0F0 - 0x0F4 */
+    uint8_t  PAD1[12];                  /* 0x0F4 - 0x100 */
+    uint32_t EIBD[PRIVATE_IRQS_NUM];    /* 0x100 - 0x180 */
+    uint8_t  PAD2[64];                  /* 0x180 - 0x1C0 */
+    uint32_t FIBD;                      /* 0x1C0 - 0x1C4 */
+    uint8_t  PAD3[60];                  /* 0x1C4 - 0x200 */
+    uint32_t EEIC[PRIVATE_IRQS_NUM];    /* 0x200 - 0x280 */
+    uint32_t EIBG;                      /* 0x280 - 0x284 */
+    uint8_t  PAD4[60];                  /* 0x284 - 0x2C0 */
+    uint32_t FIBG;                      /* 0x2C0 - 0x2C4 */
+    uint8_t  PAD5[44];                  /* 0x2C4 - 0x2F0 */
+    uint32_t IHVCFG;                    /* 0x2F0 - 0x2F4 */
+};
+
+#define INTC2_IRQ_NUM (ARCH_MAX_INTERRUPTS - PRIVATE_IRQS_NUM)
+#define INTC2_IMR_NUM ((uint32_t)((ARCH_MAX_INTERRUPTS + 0.5) / 32) - 1)
+#define INTC2_I2EIBG_OFF (0x1FE0)
+#define INTC2_EIBD_OFF (0x2000)
+#define PAD3_LEN (0x80)
+
+struct intc2 {
+    uint8_t  PAD0[64];              /* 0x0000 - 0x003F */
+    uint16_t EIC[INTC2_IRQ_NUM];    /* 0x0040 - 0x0FFF */
+    uint8_t  PAD1[4];               /* 0x1000 - 0x1003 */
+    uint32_t IMR[INTC2_IMR_NUM];    /* 0x1004 - 0x10FF */
+    uint8_t  PAD2[3808];            /* 0x1100 - 0x1FDF */
+    uint32_t I2EIBG[ARCH_MAX_CPUS]; /* 0x1FE0 - (0x1FE0 + 4*cpu_num - 1) */
+    uint8_t  PAD3[PAD3_LEN];        /* (0x1FE0 + 4*cpu_num) - 0x203F */
+    uint32_t EIBD[INTC2_IRQ_NUM];   /* 0x2080 - 0x3FFF */
+    uint8_t  PAD4[128];             /* 0x4000 - 0x403F */
+    uint32_t EEIC[INTC2_IRQ_NUM];   /* 0x4080 - 0x5FFF */
+};
+
+struct intif {
+    uint32_t PINT[8];
+    uint32_t PINTCLR[8];
+    uint32_t PAD[112];
+    uint32_t TPTMSEL;
+};
+
+struct eint {
+    uint8_t sintr[ARCH_MAX_CPUS];
+};
+
+struct fenc {
+    uint64_t FENMIF;
+    uint32_t FENMIC;
+};
+
+struct feinc {
+    uint32_t FEINTF;
+    uint32_t FEINTFMSK;
+    uint32_t FEINTC;
+    uint8_t pad0[0x100 - (3*sizeof(uint32_t))];
+};
+
+void intc_init(void);
+void intc_set_trgt(unsigned long int_id, unsigned long cpu_id);
+void intc_set_enable(unsigned long int_id, bool en);
+void intc_set_prio(unsigned long int_id, unsigned long prio);
+void intc_set_pend(unsigned long int_id, bool en);
+bool intc_get_pend(unsigned long int_id);
+
+//TODO set tpmp type (fe vs feint)
+#endif /* INTC_H */

--- a/src/arch/rh850/inc/spinlock.h
+++ b/src/arch/rh850/inc/spinlock.h
@@ -1,0 +1,49 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_SPINLOCK__
+#define __ARCH_SPINLOCK__
+
+#include <core.h>
+
+typedef uint32_t spinlock_t;
+
+#define SPINLOCK_INITVAL 0
+
+static inline void spinlock_init(spinlock_t *lock)
+{
+    *lock = 0;
+}
+
+static inline void spin_lock(spinlock_t *lock)
+{
+    __asm__ volatile(
+        "1:\n\t"
+        "    ldl.w  [%0], r19      \n\t"
+        "    cmp    r0, r19        \n\t"
+        "    bnz    2f             \n\t"
+        "    mov    1, r19         \n\t"
+        "    stc.w  r19, [%0]      \n\t"
+        "    cmp    r0, r19        \n\t"
+        "    bnz    3f             \n\t"
+        "2:\n\t"
+        "    snooze                \n\t"
+        "    br     1b             \n\t"
+        "3:\n\t"
+        :
+        : "r"(lock)
+        : "r19", "memory");
+}
+
+static inline void spin_unlock(spinlock_t *lock)
+{
+    __asm__ volatile(
+        "st.w r0, 0[%0]\n\t"
+        :
+        : "r"(lock)
+        : "memory");
+}
+
+#endif /* __ARCH_SPINLOCK__ */

--- a/src/arch/rh850/inc/srs.h
+++ b/src/arch/rh850/inc/srs.h
@@ -1,0 +1,136 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_SRS_H__
+#define __ARCH_SRS_H__
+
+/* Basic System Registers */
+#define PSW_Z              (1UL << 0)
+#define PSW_EBV            (1UL << 15)
+
+#define EIPSW_EBV          (PSW_EBV)
+#define FEPSW_EBV          (PSW_EBV)
+
+/* MPU Registers */
+#define MPM_MPE            (1UL << 0)
+#define MPM_SVP            (1UL << 1)
+#define MPCFG_HBE_OFF      (8)
+#define MPCFG_HBE_LEN      (6)
+#define MPCFG_HBE_MASK     (BIT_MASK(MPCFG_HBE_OFF, MPCFG_HBE_LEN))
+#define MPIDX_IDX_OFF      (0)
+#define MPIDX_IDX_LEN      (5)
+#define MPIDX_IDX_MASK     (BIT_MASK(MPIDX_IDX_OFF, MPIDX_IDX_LEN))
+#define MPLA_OFF           (2)
+#define MPLA_LEN           (30)
+#define MPLA_MASK          (BIT_MASK(MPLA_OFF, MPLA_LEN))
+#define MPUA_OFF           (2)
+#define MPUA_LEN           (30)
+#define MPUA_MASK          (BIT_MASK(MPUA_OFF, MPUA_LEN))
+
+#define MPCFG_NMPUE_SHIFT  (0U)
+#define MPCFG_NMPUE_MASK   (0x1FUL << MPCFG_NMPUE_SHIFT)
+#define MPCFG_GET_NMPUE(v) (((v) & MPCFG_NMPUE_MASK) >> MPCFG_NMPUE_SHIFT)
+
+#define MPAT_E_SHIFT       (7U)
+#define MPAT_E_MASK        (0x1UL << MPAT_E_SHIFT)
+#define MPAT_GET_E(v)      (((v) & MPAT_E_MASK) >> MPAT_E_SHIFT)
+
+#define TSCTRL_CEN_SHIFT   (0UL)
+#define TSCTRL_CEN_MASK    (0x1UL << TSCTRL_CEN_SHIFT)
+#define TSCTRL_GET_CEN(v)  (((v) & TSCTRL_CEN_MASK) >> TSCTRL_CEN_SHIFT)
+
+#define TSCTRL_CEN_SET(v)  ((v) | TSCTRL_CEN_MASK)
+#define TSCTRL_CEN_CLR(v)  ((v) & ~TSCTRL_CEN_MASK)
+
+#ifndef __ASSEMBLER__
+
+/* System Register accessors */
+#define SRS_GEN_ACCESSORS(name, regid, selid)                                  \
+    static inline unsigned long srs_##name##_read(void)                        \
+    {                                                                          \
+        unsigned long _temp;                                                   \
+        __asm__ volatile("stsr " #regid ", %0, " #selid "\n\r" : "=r"(_temp)); \
+        return _temp;                                                          \
+    }                                                                          \
+    static inline void srs_##name##_write(unsigned long val)                   \
+    {                                                                          \
+        __asm__ volatile("ldsr %0," #regid ", " #selid "\n\r" ::"r"(val));     \
+    }
+
+/* BASIC SYS REG */
+SRS_GEN_ACCESSORS(eipc, 0, 0)
+SRS_GEN_ACCESSORS(eipsw, 1, 0)
+SRS_GEN_ACCESSORS(fepc, 2, 0)
+SRS_GEN_ACCESSORS(fepsw, 3, 0)
+SRS_GEN_ACCESSORS(psw, 5, 0)
+SRS_GEN_ACCESSORS(fpsr, 6, 0)
+SRS_GEN_ACCESSORS(fpepc, 7, 0)
+SRS_GEN_ACCESSORS(fpst, 8, 0)
+SRS_GEN_ACCESSORS(fpcc, 9, 0)
+SRS_GEN_ACCESSORS(fpcfg, 10, 0)
+SRS_GEN_ACCESSORS(eiic, 13, 0)
+SRS_GEN_ACCESSORS(feic, 14, 0)
+SRS_GEN_ACCESSORS(ctpc, 16, 0)
+SRS_GEN_ACCESSORS(ctpsw, 17, 0)
+SRS_GEN_ACCESSORS(ctbp, 20, 0)
+SRS_GEN_ACCESSORS(snzcfg, 21, 0)
+SRS_GEN_ACCESSORS(eiwr, 28, 0)
+SRS_GEN_ACCESSORS(fewr, 29, 0)
+SRS_GEN_ACCESSORS(spid, 0, 1)
+SRS_GEN_ACCESSORS(spidlist, 1, 1)
+SRS_GEN_ACCESSORS(rbase, 2, 1)
+SRS_GEN_ACCESSORS(ebase, 3, 1)
+SRS_GEN_ACCESSORS(peid, 0, 2)
+SRS_GEN_ACCESSORS(bmid, 1, 2)
+SRS_GEN_ACCESSORS(intbp, 4, 1)
+SRS_GEN_ACCESSORS(mea, 6, 2)
+SRS_GEN_ACCESSORS(mei, 8, 2)
+SRS_GEN_ACCESSORS(rbip, 18, 2)
+
+/* TIME STAMP */
+SRS_GEN_ACCESSORS(tscountl, 0, 11)
+SRS_GEN_ACCESSORS(tscounth, 1, 11)
+SRS_GEN_ACCESSORS(tsctrl, 2, 11)
+
+/* INTERRUPT SYS REGS */
+SRS_GEN_ACCESSORS(ispr, 10, 2)
+SRS_GEN_ACCESSORS(imsr, 11, 2)
+SRS_GEN_ACCESSORS(icsr, 12, 2)
+SRS_GEN_ACCESSORS(intcfg, 13, 2)
+SRS_GEN_ACCESSORS(plmr, 14, 2)
+
+/* MPU FUNCTION REGISTERS */
+SRS_GEN_ACCESSORS(mpm, 0, 5)
+SRS_GEN_ACCESSORS(mpcfg, 2, 5)
+SRS_GEN_ACCESSORS(mca, 8, 5)
+SRS_GEN_ACCESSORS(mcs, 9, 5)
+SRS_GEN_ACCESSORS(mcc, 10, 5)
+SRS_GEN_ACCESSORS(mcr, 11, 5)
+SRS_GEN_ACCESSORS(mci, 12, 5)
+SRS_GEN_ACCESSORS(mpidx, 16, 5)
+SRS_GEN_ACCESSORS(mpbk, 17, 5)
+SRS_GEN_ACCESSORS(mpla, 20, 5)
+SRS_GEN_ACCESSORS(mpua, 21, 5)
+SRS_GEN_ACCESSORS(mpat, 22, 5)
+SRS_GEN_ACCESSORS(mpid0, 24, 5)
+SRS_GEN_ACCESSORS(mpid1, 25, 5)
+SRS_GEN_ACCESSORS(mpid2, 26, 5)
+SRS_GEN_ACCESSORS(mpid3, 27, 5)
+SRS_GEN_ACCESSORS(mpid4, 28, 5)
+SRS_GEN_ACCESSORS(mpid5, 29, 5)
+SRS_GEN_ACCESSORS(mpid6, 30, 5)
+SRS_GEN_ACCESSORS(mpid7, 31, 5)
+
+/* CACHE OPERATION REGISTERS */
+SRS_GEN_ACCESSORS(ictagl, 16, 4)
+SRS_GEN_ACCESSORS(ictagh, 17, 4)
+SRS_GEN_ACCESSORS(icdatl, 18, 4)
+SRS_GEN_ACCESSORS(icdath, 19, 4)
+SRS_GEN_ACCESSORS(icctrl, 24, 4)
+SRS_GEN_ACCESSORS(iccfg, 26, 4)
+SRS_GEN_ACCESSORS(icerr, 28, 4)
+
+#endif /* __ASSEMBLER__ */
+#endif /* __ARCH_SRS_H__ */

--- a/src/arch/rh850/inc/wfi.h
+++ b/src/arch/rh850/inc/wfi.h
@@ -1,0 +1,8 @@
+#ifndef WFI_H
+#define WFI_H
+
+static inline void wfi(){
+    asm volatile("snooze\n\t");
+}
+
+#endif

--- a/src/arch/rh850/init.c
+++ b/src/arch/rh850/init.c
@@ -1,0 +1,22 @@
+#include <core.h>
+#include <intc.h>
+#include <timer.h>
+#include <cpu.h>
+
+extern void _start();
+
+static inline void ei(){
+    asm volatile("ei\n\t");
+}
+
+void arch_init(){
+
+#ifndef SINGLE_CORE
+    if(cpu_is_master()){
+        static volatile uint32_t *const BOOTCTRL = (void*) PLAT_BOOTCTRL_ADDR;
+        *BOOTCTRL = ~0UL;
+    }
+#endif
+    intc_init();
+    ei();
+}

--- a/src/arch/rh850/intc.c
+++ b/src/arch/rh850/intc.c
@@ -1,0 +1,146 @@
+#include <intc.h>
+#include <cpu.h>
+#include <plat.h>
+
+volatile struct intc1* intc1_hw = (void*) PLAT_INTC1_BASE;
+volatile struct intc2* intc2_hw = (void*) PLAT_INTC2_BASE;
+volatile struct intif* intif_hw = (void*) PLAT_INTIF_BASE;
+volatile struct eint* eint_hw = (void*) PLAT_EINTS_BASE;
+volatile struct fenc* fenc_hw = (void*) PLAT_FENC_BASE;
+volatile struct feinc* feinc_hw = (void*) PLAT_FEINC_BASE;
+
+// EIC Register Bit Definitions
+#define EICTn_BIT                (1 << 15)
+#define EIRFn_BIT                (1 << 12)
+#define EIMKn_BIT                (1 << 7)
+#define EITBn_BIT                (1 << 6)
+#define EIOVn_BIT                (1 << 5)
+
+// EIPn Mask (Bits 3-0)
+#define EIPn_MASK                (0xF)
+
+// Macro to Set/Reset EICTn
+#define EIC_SET_EICTn(reg)       ((reg) |= EICTn_BIT)        // Set EICTn to 1 (Detection by level)
+#define EIC_CLR_EICTn(reg)       ((reg) &= ~EICTn_BIT)       // Clear EICTn to 0 (Detection by edge)
+#define EIC_GET_EICTn(reg)       (((reg) & EICTn_BIT) >> 15) // Read EICTn value
+
+// Macro to Set/Reset EIRFn
+#define EIC_SET_EIRFn(reg)       ((reg) |= EIRFn_BIT)  // Set EIRFn to 1 (Interrupt request present)
+#define EIC_CLR_EIRFn(reg)       ((reg) &= ~EIRFn_BIT) // Clear EIRFn to 0 (No interrupt request)
+#define EIC_GET_EIRFn(reg)       (((reg) & EIRFn_BIT) >> 12) // Read EIRFn value
+
+// Macro to Set/Reset EIMKn
+#define EIC_SET_EIMKn(reg)       ((reg) |= EIMKn_BIT)       // Mask interrupt
+#define EIC_CLR_EIMKn(reg)       ((reg) &= ~EIMKn_BIT)      // Unmask interrupt
+#define EIC_GET_EIMKn(reg)       (((reg) & EIMKn_BIT) >> 7) // Read EIMKn value
+
+// Macro to Set/Reset EITBn
+#define EIC_SET_EITBn(reg)       ((reg) |= EITBn_BIT)  // Set EITBn to 1 (Table reference method)
+#define EIC_CLR_EITBn(reg)       ((reg) &= ~EITBn_BIT) // Set EITBn to 0 (Direct vector method)
+#define EIC_GET_EITBn(reg)       (((reg) & EITBn_BIT) >> 6) // Read EITBn value
+
+// Macro to Set/Reset EIOVn
+#define EIC_SET_EIOVn(reg)       ((reg) |= EIOVn_BIT)       // Set EIOVn to 1 (Interrupt overflow)
+#define EIC_CLR_EIOVn(reg)       ((reg) &= ~EIOVn_BIT)      // Clear EIOVn to 0 (No overflow)
+#define EIC_GET_EIOVn(reg)       (((reg) & EIOVn_BIT) >> 5) // Read EIOVn value
+
+// Macro to Set/Reset EIPn
+#define EIC_SET_EIPn(reg, value) ((reg) = ((reg) & ~EIPn_MASK) | ((value) & EIPn_MASK))
+#define EIC_GET_EIPn(reg)        ((reg) & EIPn_MASK)
+
+// EIBD Register Bit Definitions
+#define EIBD_GM_BIT              (1 << 15) // Guest Mode Bit
+
+// GPID[2:0] Mask (Bits 10-8)
+#define EIBD_GPID_MASK           (0x7 << 8) // 3-bit mask for GPID field
+#define EIBD_GPID_SHIFT          8          // GPID starting position
+
+// PEID[2:0] Mask (Bits 2-0)
+#define EIBD_PEID_MASK           (0x7) // 3-bit mask for PEID field
+
+// Macro to Set/Reset GM
+#define EIBD_SET_GM(reg)         ((reg) |= EIBD_GM_BIT)  // Set GM to 1 (Channel bound to Guest)
+#define EIBD_CLR_GM(reg)         ((reg) &= ~EIBD_GM_BIT) // Clear GM to 0 (Channel bound to Host)
+#define EIBD_GET_GM(reg)         (((reg) & EIBD_GM_BIT) >> 15) // Read GM value
+
+// Macro to Set GPID (Bits 10-8)
+#define EIBD_SET_GPID(reg, value) \
+    ((reg) = ((reg) & ~EIBD_GPID_MASK) | (((value) & 0x7) << EIBD_GPID_SHIFT))
+#define EIBD_GET_GPID(reg)        (((reg) & EIBD_GPID_MASK) >> EIBD_GPID_SHIFT)
+
+// Macro to Set PEID (Bits 2-0)
+#define EIBD_SET_PEID(reg, value) ((reg) = ((reg) & ~EIBD_PEID_MASK) | ((value) & EIBD_PEID_MASK))
+#define EIBD_GET_PEID(reg)        ((reg) & EIBD_PEID_MASK)
+
+void intc_set_pend(unsigned long int_id, bool en)
+{
+    if (int_id < PRIVATE_IRQS_NUM) {
+        if (en) {
+            EIC_SET_EIRFn(intc1_hw->EIC[int_id]);
+        } else {
+            EIC_CLR_EIRFn(intc1_hw->EIC[int_id]);
+        }
+    } else {
+        unsigned long intc2_irq_id = int_id - PRIVATE_IRQS_NUM;
+        if (en) {
+            EIC_SET_EIRFn(intc2_hw->EIC[intc2_irq_id]);
+        } else {
+            EIC_CLR_EIRFn(intc2_hw->EIC[intc2_irq_id]);
+        }
+    }
+}
+
+bool intc_get_pend(unsigned long int_id)
+{
+    unsigned int pend = 0;
+    if (int_id < PRIVATE_IRQS_NUM) {
+        pend = EIC_GET_EIRFn(intc1_hw->EIC[int_id]);
+
+    } else {
+        unsigned long intc2_irq_id = int_id - PRIVATE_IRQS_NUM;
+        pend = EIC_GET_EIRFn(intc2_hw->EIC[intc2_irq_id]);
+    }
+
+    return !!pend;
+}
+
+void intc_set_trgt(unsigned long int_id, unsigned long cpu_id)
+{
+    if (int_id >= PRIVATE_IRQS_NUM) {
+        unsigned long intc2_irq_id = int_id - PRIVATE_IRQS_NUM;
+        EIBD_SET_PEID(intc2_hw->EIBD[intc2_irq_id], cpu_id);
+    }
+}
+
+void intc_set_enable(unsigned long int_id, bool en)
+{
+    if (int_id < PRIVATE_IRQS_NUM) {
+        if (en) {
+            EIC_CLR_EIMKn(intc1_hw->EIC[int_id]);
+        } else {
+            EIC_SET_EIMKn(intc1_hw->EIC[int_id]);
+        }
+    } else {
+        unsigned long intc2_irq_id = int_id - PRIVATE_IRQS_NUM;
+        if (en) {
+            EIC_CLR_EIMKn(intc2_hw->EIC[intc2_irq_id]);
+        } else {
+            EIC_SET_EIMKn(intc2_hw->EIC[intc2_irq_id]);
+        }
+    }
+}
+
+void intc_set_prio(unsigned long int_id, unsigned long prio)
+{
+    if (int_id < PRIVATE_IRQS_NUM) {
+        EIC_SET_EIPn(intc1_hw->EIC[int_id], prio);
+    } else {
+        unsigned long intc2_irq_id = int_id - PRIVATE_IRQS_NUM;
+        EIC_SET_EIPn(intc2_hw->EIC[intc2_irq_id], prio);
+    }
+}
+
+void intc_init()
+{
+
+}

--- a/src/arch/rh850/irq.c
+++ b/src/arch/rh850/irq.c
@@ -1,0 +1,53 @@
+#include <intc.h>
+#include <cpu.h>
+#include <plat.h>
+#include <arch/irq.h>
+
+#define IPIR_CHANNEL_NUM 4
+
+struct ipir_chann {
+    uint8_t IPInEN;
+    uint8_t pad0[0x4-0x1];
+    uint8_t IPInFLG;
+    uint8_t pad1[0x8-0x5];
+    uint8_t IPInFCLR;
+    uint8_t pad2[0x10-0x9];
+    uint8_t IPInREQ;
+    uint8_t pad3[0x14-0x11];
+    uint8_t IPInRCLR;
+    uint8_t pad4[0x20-0x15];
+};
+
+struct ipir_pe_set {
+    struct ipir_chann chann[4];
+    uint8_t pad[0x100-0x80];
+};
+
+struct ipir_hw {
+    struct ipir_chann self[4];
+    uint8_t pad[0x800-0x80];
+    struct ipir_pe_set pe[4];
+};
+
+static volatile struct ipir_hw* ipir = (void*)PLAT_IPIR_BASE;
+
+void irq_enable(unsigned id) {
+    intc_set_enable(id, true);
+    intc_set_trgt(id, get_cpuid());
+    if (id == IPI_IRQ_ID) {
+        ipir->self[IPI_IRQ_ID].IPInEN = (uint8_t)0xFU;
+    }
+}
+
+void irq_set_prio(unsigned id, unsigned prio) {
+    intc_set_prio(id, prio);
+}
+
+void irq_send_ipi(unsigned long target_cpu_mask) {
+    ipir->self[IPI_IRQ_ID].IPInREQ = target_cpu_mask;
+}
+
+void irq_clear_ipi(void) {
+    uint8_t src_cpu = ipir->self[IPI_IRQ_ID].IPInFLG;
+    ipir->self[IPI_IRQ_ID].IPInFCLR = src_cpu;
+}

--- a/src/arch/rh850/sources.mk
+++ b/src/arch/rh850/sources.mk
@@ -1,0 +1,2 @@
+arch_c_srcs:= init.c intc.c irq.c
+arch_s_srcs:= start.S exceptions.S

--- a/src/arch/rh850/start.S
+++ b/src/arch/rh850/start.S
@@ -1,0 +1,134 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <plat.h>
+#include <core.h>
+
+#define CPU_MASTER  0x0
+#define STACK_SIZE  0x200
+
+.macro LOAD_ADDR    sym, reg
+    movhi hi(\sym), r0, \reg
+    movea lo(\sym), \reg, \reg
+.endm
+
+.section ".start", "ax"
+.balign	2
+.global _start
+_start:
+    // Disable interrupts
+    di
+
+    // get current CPU
+    // r5 = PEID
+    stsr 0, r5, 2
+
+    // set PSW.EBV
+    mov 0x3f08020, r2
+    ldsr r2, 5, 0
+
+    // set EBASE (regID 3, selID 1)
+    LOAD_ADDR _vector_table, r2
+    ori 0x2, r2, r2
+    ldsr r2, 3, 1
+
+    // disable memory protections
+    mov r0, r2
+    ldsr r2, 0, 5
+
+    // cover all memory with protection check
+    ldsr r0, 8, 5 // Set the address to MCA
+    ldsr r0, 9, 5 // Set the size to MCS
+
+    // individual protections per cpu TODO should it be otherwise?
+    ldsr r0, 12, 5 // set MCI to 0
+    ldsr r0, 0, 1 // set SPID host SPID 0
+
+    jarl clear_mpu, lp
+
+    // check if current CPU is CPU_MASTER
+    mov CPU_MASTER, r10
+    cmp r5, r10
+    bne skip
+
+    // initialize RAM
+    mov RW_MEM_BASE, r20
+    mov RW_MEM_BASE+RW_MEM_SIZE, r21
+    jarl boot_clear, lp
+
+    // copy .data to RAM
+    LOAD_ADDR __data_load_start, r20
+    LOAD_ADDR __data_load_end, r21
+    LOAD_ADDR __data_start, r22
+    jarl copy_data, lp
+
+    // clear .bss
+    LOAD_ADDR __bss_start, r20
+    LOAD_ADDR __bss_end, r21
+    jarl boot_clear, lp
+
+skip:
+    // Initialize stack pointer
+    LOAD_ADDR _stack_base, r20
+    mov STACK_SIZE, r21
+    add r21, r20
+    mulh r5, r21
+    add r21, r20
+    mov r20, sp
+
+    // Initialize global and text pointer
+    LOAD_ADDR __gp, gp
+    LOAD_ADDR __init, tp
+
+    jr __init
+
+// r20: start of region
+// r21: end of region
+boot_clear:
+boot_clear_1:
+    cmp r21, r20
+    bge boot_clear_exit
+    st.w r0, 0[r20]
+    addi 4, r20, r20
+    br boot_clear_1
+boot_clear_exit:
+    jmp [lp]
+
+
+// r20: start of the source region
+// r21: end of the source region
+// r22: start of the destination region
+// uses r23
+copy_data:
+copy_data_1:
+    ld.w 0[r20], r23
+    st.w r23, 0[r22]
+    addi 4, r20, r20
+    addi 4, r22, r22
+    cmp r20, r21
+    bne copy_data_1
+    jmp [lp]
+
+
+clear_mpu:
+    mov r0, r20
+    stsr 2, r21, 5      /* r16 = MPCFG (SR2, sel 5) */
+    andi 0x1F, r21, r21 /* r16 = NMPUE (bits 4..0) */
+    addi 1, r16, r21    /* r16 = NMPUE + 1 = entry count */
+clear_mpu_1:
+    cmp r20, r21
+    be clear_mpu_exit
+
+    ldsr r20, 16, 5 // set MPIDX
+
+    ldsr r0, 20, 5 // set MPLA
+    ldsr r0, 21, 5 // set MPUA
+    ldsr r0, 22, 5 // set MPAT
+
+    addi 1, r20, r20
+    br clear_mpu_1
+clear_mpu_exit:
+    jmp [lp]

--- a/src/drivers/renesas_rlin3/inc/renesas_rlin3.h
+++ b/src/drivers/renesas_rlin3/inc/renesas_rlin3.h
@@ -1,0 +1,54 @@
+#ifndef RENESAS_RLIN3_H
+#define RENESAS_RLIN3_H
+
+#include <core.h>
+#include <spinlock.h>
+
+struct renesas_rlin3 {
+    uint8_t pad0[1];                // 0x0
+    volatile uint8_t RLN3nLWBR;     // 0x1
+    volatile uint16_t RLN3nLBRP01;  // 0x2
+    volatile uint8_t RLN3nLSTC;     // 0x4
+    volatile uint8_t pad1[3];       // 0x5
+    volatile uint8_t RLN3nLMD;      // 0x8
+    volatile uint8_t RLN3nLBFC;     // 0x9
+    volatile uint8_t RLN3nLSC;      // 0xa
+    volatile uint8_t RLN3nLWUP;     // 0xb
+    volatile uint8_t RLN3nLIE;      // 0xc
+    volatile uint8_t RLN3nLEDE;     // 0xd
+    volatile uint8_t RLN3nLCUC;     // 0xe
+    volatile uint8_t pad2[1];       // 0xf
+    volatile uint8_t RLN3nLTRC;     // 0x10
+    volatile uint8_t RLN3nLMST;     // 0x11
+    volatile uint8_t RLN3nLST;      // 0x12
+    volatile uint8_t RLN3nLEST;     // 0x13
+    volatile uint8_t RLN3nLDFC;     // 0x14
+    volatile uint8_t RLN3nLIDB;     // 0x15
+    volatile uint8_t RLN3nLCBR;     // 0x16
+    volatile uint8_t RLN3nLUDB0;    // 0x17
+    volatile uint8_t RLN3nLDBR1;    // 0x18
+    volatile uint8_t RLN3nLDBR2;    // 0x19
+    volatile uint8_t RLN3nLDBR3;    // 0x1a
+    volatile uint8_t RLN3nLDBR4;    // 0x1b
+    volatile uint8_t RLN3nLDBR5;    // 0x1c
+    volatile uint8_t RLN3nLDBR6;    // 0x1d
+    volatile uint8_t RLN3nLDBR7;    // 0x1e
+    volatile uint8_t RLN3nLDBR8;    // 0x1f
+    volatile uint8_t RLN3nLUOER;    // 0x20
+    volatile uint8_t RLN3nLUOR1;    // 0x21
+    uint8_t pad3[2];                // 0x22
+    volatile uint16_t RLN3nLUTDR;   // 0x24
+    volatile uint16_t RLN3nLURDR;   // 0x26
+    volatile uint16_t RLN3nLUWTDR;  // 0x28
+    volatile uint8_t RLN3nLBSS;     // 0x30
+    volatile uint8_t pad4[3];       // 0x31
+    volatile uint8_t RLN3nLRSS;     // 0x34
+};
+
+void renesas_rlin3_init(volatile struct renesas_rlin3* uart);
+void renesas_rlin3_putc(volatile struct renesas_rlin3* uart, int8_t c);
+uint32_t renesas_rlin3_getc(volatile struct renesas_rlin3* uart);
+void renesas_rlin3_enable_rxirq(volatile struct renesas_rlin3 *uart);
+void renesas_rlin3_clear_rxirq(volatile struct renesas_rlin3* uart);
+
+#endif /* RENESAS_RLIN3_H */

--- a/src/drivers/renesas_rlin3/renesas_rlin3.c
+++ b/src/drivers/renesas_rlin3/renesas_rlin3.c
@@ -1,0 +1,84 @@
+#include <renesas_rlin3.h>
+
+#define RLIN3_LWBR_LPRS_16      (0x4 << 1)
+#define RLIN3_LWBR_NSPB_10      (0x9 << 4)
+#define RLN3_LBFC_UBLS_8B       (0)
+#define RLN3_LBFC_UBOS_LSB      (0)
+#define RLN3_LBFC_USBLS_1B      (0)
+#define RLN3_LBFC_UPS_DIS       (0)
+#define RLIN3_LMST_OMM0_MSK     (1)
+#define RLN3_LUOER_UROE         (0x1 << 1)
+#define RLN3_LUOER_UTOE         (0x1 << 0)
+#define RLN3_LST_UTS_MSK        (0x1 << 4)
+#define RLN3_LST_URS_MSK        (0x1 << 5)
+#define RLN3_LMD_UART_MODE      (0x1)
+#define RLN3_LCUC_LIN_CANC      (0x1)
+
+#define KCPROT_ENABLE          0xA5A5A501UL
+#define KCPROT_DISABLE         0xA5A5A500UL
+#define MSRKCPROT              0xFF981710UL
+#define MSR_RLIN3              0xFF981060UL
+
+volatile unsigned int uart_rxcnt = 0;
+spinlock_t rx_lock = SPINLOCK_INITVAL;
+
+void renesas_rlin3_init(volatile struct renesas_rlin3* uart)
+{
+    *((volatile uint32_t*) MSRKCPROT) = KCPROT_ENABLE;
+    *((volatile uint32_t*) MSR_RLIN3) = 0;
+    *((volatile uint32_t*) MSRKCPROT) = KCPROT_DISABLE;
+
+    // Set reset mode
+    uart->RLN3nLCUC = 0;
+
+    while ((uart->RLN3nLMST & RLIN3_LMST_OMM0_MSK) != 0x0) {
+    }
+
+    // Set baud rate to 500000 assuming CLK_RLIN = 80 MHz
+    uart->RLN3nLWBR = 0; // prescaler reset;
+    uart->RLN3nLWBR = RLIN3_LWBR_LPRS_16 | RLIN3_LWBR_NSPB_10;
+    uart->RLN3nLBRP01 = 0;
+
+    // Set data format
+    uart->RLN3nLBFC =
+        RLN3_LBFC_UBLS_8B |
+        RLN3_LBFC_UBOS_LSB |
+        RLN3_LBFC_USBLS_1B |
+        RLN3_LBFC_UPS_DIS;
+
+
+    // Set uart mode
+    uart->RLN3nLMD = RLN3_LMD_UART_MODE;
+    uart->RLN3nLCUC = RLN3_LCUC_LIN_CANC;
+
+    while ((uart->RLN3nLMST & RLIN3_LMST_OMM0_MSK) != 0x1) {
+    }
+
+    // Enable reception and transmission
+    uart->RLN3nLUOER = RLN3_LUOER_UROE | RLN3_LUOER_UTOE;
+}
+
+void renesas_rlin3_putc(volatile struct renesas_rlin3* uart, int8_t c)
+{
+    while (uart->RLN3nLST & RLN3_LST_UTS_MSK);
+    uart->RLN3nLUTDR = c;
+}
+
+uint32_t renesas_rlin3_getc(volatile struct renesas_rlin3* uart)
+{
+    while(!uart_rxcnt);
+
+    uart_rxcnt--;
+
+    return uart->RLN3nLURDR;
+}
+
+void renesas_rlin3_enable_rxirq(volatile struct renesas_rlin3 *uart)
+{
+    // Enabled by default
+}
+
+void renesas_rlin3_clear_rxirq(volatile struct renesas_rlin3 *uart)
+{
+    // Done automatically
+}

--- a/src/drivers/renesas_rlin3/sources.mk
+++ b/src/drivers/renesas_rlin3/sources.mk
@@ -1,0 +1,2 @@
+driver_c_srcs+=renesas_rlin3/renesas_rlin3.c
+driver_s_srcs+=

--- a/src/drivers/rh850-u2a16_ostm/inc/rh850-u2a16_ostm.h
+++ b/src/drivers/rh850-u2a16_ostm/inc/rh850-u2a16_ostm.h
@@ -1,0 +1,47 @@
+#ifndef RH850_U2A16_OSTM_H
+#define RH850_U2A16_OSTM_H
+
+#include <core.h>
+
+struct rh850_u2a16_OSTMn {
+    volatile uint32_t OSTMnCMP;     // 0x00
+    volatile uint32_t OSTMnCNT;     // 0x04
+    volatile uint8_t OSTMnTO;       // 0x08
+    uint8_t PAD0[3];
+    volatile uint8_t OSTMnTOE;      // 0x0C
+    uint8_t PAD1[3];
+    volatile uint8_t OSTMnTE;       // 0x10
+    uint8_t PAD2[3];
+    volatile uint8_t OSTMnTS;       // 0x14
+    uint8_t PAD3[3];
+    volatile uint8_t OSTMnTT;       // 0x18
+    uint8_t PAD4[7];
+    volatile uint8_t OSTMnCTL;      // 0x20
+
+    // Used for OSTM8 and OSTM9
+    // volatile uint16_t IC0CKSEL8;
+    // volatile uint16_t IC0CKSEL9;
+};
+
+static inline void rh850_u2a16_OSTMn_enable(volatile struct rh850_u2a16_OSTMn* timer) {
+    timer->OSTMnCTL |= (0b00000010); // Set to Free-run compare mode
+    timer->OSTMnCTL &= (0b11111110); // Disable interrupts when counting starts, we don't need it
+    timer->OSTMnCTL &= (0b11111011); // Set OSTMnMD2 to 0, it will reset CNT to 0x0 when start.
+
+    // Enable interrupt
+    timer->OSTMnCTL |= (0b10000000);
+}
+
+static inline uint64_t rh850_u2a16_OSTMn_get(volatile struct rh850_u2a16_OSTMn* timer) {
+    return timer->OSTMnCNT;
+}
+
+static inline void rh850_u2a16_OSTMn_set(volatile struct rh850_u2a16_OSTMn* timer, uint64_t n) {
+    // Stop
+    timer->OSTMnTT = 0x01;
+    // Reset CMP, CNT will reset to 0
+    timer->OSTMnCMP = n;
+    // Start
+    timer->OSTMnTS |= (0x01);
+}
+#endif /* RH850_U2A16_OSTM_H */

--- a/src/ld/linker_non_unified.ld
+++ b/src/ld/linker_non_unified.ld
@@ -3,7 +3,6 @@
 
 MEMORY
 {
-  /* Keep consistent with bao-demos/config.c */
   RO_MEM : ORIGIN = RO_MEM_BASE, LENGTH = RO_MEM_SIZE
   RW_MEM : ORIGIN = RW_MEM_BASE, LENGTH = RW_MEM_SIZE
 }

--- a/src/platform/rh850-u2a16/inc/plat.h
+++ b/src/platform/rh850-u2a16/inc/plat.h
@@ -1,0 +1,40 @@
+#ifndef PLAT_H
+#define PLAT_H
+
+#include <core.h>
+
+#define PLAT_RO_MEM_BASE 0x7F0000
+#define PLAT_RO_MEM_SIZE 0x10000
+
+#define PLAT_RW_MEM_BASE 0xFE100000
+#define PLAT_RW_MEM_SIZE 0x80000
+
+#define PLAT_STACKHEAP_SIZE 0x2000
+
+/* --------------------------------------- */
+
+#define PLAT_CLK_RLIN  (80000000) // 80 MHz
+#define PLAT_UART_ADDR (0xFFC7C100) // RLIN35 Base
+#define UART_IRQ_ID    (438) // RLIN35 Receive completion interrupt
+
+#define PLAT_OSTM0_BASE  (0xFFBF0000UL) // OSTM0
+#define PLAT_CLK_CPU     (400000000UL)  // 400 MHz. This value depends on CKDIVMD OPTION BYTE.
+// OSTM0 timer interrupt
+#define TIMER_IRQ_ID (199UL)
+
+#define PLAT_INTC1_BASE  (0xFFFC0000UL)
+#define PLAT_INTC2_BASE  (0xFFF80000UL)
+#define PLAT_INTIF_BASE  (0xFF090000UL)
+#define PLAT_EINTS_BASE  (0xFFC00000UL)
+#define PLAT_FENC_BASE   (0xFF9A3A00UL)
+#define PLAT_FEINC_BASE  (0xFF9A3B00UL)
+#define PLAT_IPIR_BASE   (0xFFFB9000UL)
+
+#define PLAT_BOOTCTRL_ADDR  (0xFFFB2000UL)
+
+#define PLAT_CLK_HSB (80000000UL)
+
+// OSTM use CLK_HSB
+#define TIMER_FREQ PLAT_CLK_HSB
+
+#endif

--- a/src/platform/rh850-u2a16/plat.mk
+++ b/src/platform/rh850-u2a16/plat.mk
@@ -1,0 +1,3 @@
+ARCH:=rh850
+drivers:=renesas_rlin3 rh850-u2a16_ostm
+MEM_MODEL:=NON_UNIFIED

--- a/src/platform/rh850-u2a16/sources.mk
+++ b/src/platform/rh850-u2a16/sources.mk
@@ -1,0 +1,2 @@
+plat_c_srcs:=u2a16.c
+plat_s_srcs:=

--- a/src/platform/rh850-u2a16/u2a16.c
+++ b/src/platform/rh850-u2a16/u2a16.c
@@ -1,0 +1,42 @@
+#include <renesas_rlin3.h>
+#include <rh850-u2a16_ostm.h>
+
+#include <plat.h>
+
+static volatile struct renesas_rlin3 *uart = (void*)PLAT_UART_ADDR;
+
+static volatile struct rh850_u2a16_OSTMn* timer = (void*)PLAT_OSTM0_BASE;
+
+void uart_init(){
+    renesas_rlin3_init(uart);
+}
+
+void uart_putc(char c)
+{
+    renesas_rlin3_putc(uart, c);
+}
+
+char uart_getchar(void) {
+    return renesas_rlin3_getc(uart);
+}
+
+void uart_enable_rxirq() {
+    renesas_rlin3_enable_rxirq(uart);
+}
+
+void uart_clear_rxirq() {
+    renesas_rlin3_clear_rxirq(uart);
+}
+
+void timer_enable() {
+    rh850_u2a16_OSTMn_enable(timer);
+}
+
+uint64_t timer_get() {
+    return rh850_u2a16_OSTMn_get(timer);
+}
+
+void timer_set(uint64_t n) {
+    rh850_u2a16_OSTMn_set(timer, n);
+}
+


### PR DESCRIPTION
feat(rh850-u2a16): Add baremetal demo, and change the compilation toolchain to gcc

- Add a baremetal program that can run according to the logic of main.c, compatible with rh850-u2a16
- Change the compilation toolchain and environment to gcc, and no longer use CCRH or GHS


Under the current compilation parameters, the newlib-nano library will be used for linking. printf will be divided into puts and iprintf based on whether formatting is required.

The specific definition can be found at https://github.com/32bitmicro/newlib-nano-1.0/blob/master/newlib/libc/stdio/printf.c

iprintf is an alias for printf, so I directly overrode printf and puts in 'print.c'. However, I don't think this is a particularly important issue. If we change the compilation options later, it will be very easy to migrate.

