### PR TITLE
fix/armv8-timer-int: mask timer interrupt in init

### DIFF
--- a/src/arch/armv8/inc/arch/timer.h
+++ b/src/arch/armv8/inc/arch/timer.h
@@ -6,6 +6,11 @@
 
 extern unsigned long TIMER_FREQ;
 
+static inline unsigned long timer_get_freq(void)
+{
+    return sysreg_cntfrq_el0_read();
+}
+
 static inline void timer_set(uint64_t n)
 {
     uint64_t current = sysreg_cntvct_el0_read();

--- a/src/arch/armv8/inc/arch/timer.h
+++ b/src/arch/armv8/inc/arch/timer.h
@@ -6,9 +6,27 @@
 
 extern unsigned long TIMER_FREQ;
 
+#define CNTV_CTL_ENABLE (1 << 0)
+#define CNTV_CTL_IMASK  (1 << 1)
+
 static inline unsigned long timer_get_freq(void)
 {
     return sysreg_cntfrq_el0_read();
+}
+
+static inline void timer_int_en(bool en)
+{
+    if (en) {
+        sysreg_cntv_ctl_el0_write(sysreg_cntv_ctl_el0_read() & ~CNTV_CTL_IMASK);
+    } else {
+        sysreg_cntv_ctl_el0_write(sysreg_cntv_ctl_el0_read() | CNTV_CTL_IMASK);
+    }
+}
+
+static inline void timer_enable(void)
+{
+    timer_int_en(true);
+    sysreg_cntv_ctl_el0_write(CNTV_CTL_ENABLE);
 }
 
 static inline void timer_set(uint64_t n)

--- a/src/arch/armv8/init.c
+++ b/src/arch/armv8/init.c
@@ -12,8 +12,8 @@ __attribute__((weak))
 void arch_init(){
     unsigned long cpuid = get_cpuid();
     gic_init();
-    sysreg_cntv_ctl_el0_write(1);
     TIMER_FREQ = timer_get_freq();
+    timer_int_en(false);
 
 #if !(defined(SINGLE_CORE) || defined(NO_FIRMWARE))
     if(cpuid == 0){

--- a/src/arch/armv8/init.c
+++ b/src/arch/armv8/init.c
@@ -12,8 +12,8 @@ __attribute__((weak))
 void arch_init(){
     unsigned long cpuid = get_cpuid();
     gic_init();
-    TIMER_FREQ = sysreg_cntfrq_el0_read();
     sysreg_cntv_ctl_el0_write(1);
+    TIMER_FREQ = timer_get_freq();
 
 #if !(defined(SINGLE_CORE) || defined(NO_FIRMWARE))
     if(cpuid == 0){

--- a/src/main.c
+++ b/src/main.c
@@ -64,6 +64,8 @@ void main(void){
         irq_enable(TIMER_IRQ_ID);
         irq_set_prio(TIMER_IRQ_ID, TIMER_IRQ_PRIO);
 
+        timer_enable();
+
         master_done = true;
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the ARMv8 timer initialization and control logic. The main changes include refactoring timer enable and interrupt enable functionality into dedicated inline functions and updating initialization routines. Previously, the timer interrupt was not masked during `arch_init` which could lead to an immediate interrupt as soon as a new value was set in `timer_set`. 
