### PR TITLE
feat(s32z270): add nxp s32z270 platform support

### DIFF
--- a/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
+++ b/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
@@ -48,7 +48,7 @@
     static inline unsigned long long sysreg_##reg##_read() {\
         unsigned long long _temp, _tempH;\
         asm volatile("mrrc p15, "#op1", %0, %1, "#crm"\n\r": "=r"(_temp), "=r"(_tempH));\
-        return ((_tempH << 32) | _temp);\
+        return ((_tempH << 32) | (unsigned long)_temp);\
     } \
     static inline void sysreg_##reg##_write(unsigned long long val) {\
         unsigned long long _tempH = (val>>32);\

--- a/src/arch/armv8/aarch32/sources.mk
+++ b/src/arch/armv8/aarch32/sources.mk
@@ -1,2 +1,5 @@
 arch_c_srcs:=
-arch_s_srcs+=$(addprefix $(ARCH_SUB)/, exceptions.S page_tables.S start.S)
+arch_s_srcs+=$(addprefix $(ARCH_SUB)/, exceptions.S start.S)
+ifndef MPU
+arch_s_srcs+=$(addprefix $(ARCH_SUB)/, page_tables.S)
+endif

--- a/src/arch/armv8/aarch32/start.S
+++ b/src/arch/armv8/aarch32/start.S
@@ -86,14 +86,14 @@ entry_el1:
     ldr r1, =(SCTLR_RES1 | SCTLR_C | SCTLR_I | SCTLR_BR | SCTLR_M)
     mcr p15, 0, r1, c1, c0, 0 // sctlr
 
-#else 
+#else
 
     ldr r1, =0x55555555
     mcr p15, 0, r1, c3, c0, 0 // dacr
 
     mov r1, #0
     mcr p15, 0, r1, c2, c0, 2 // ttbcr
-    
+
     ldr r1, =page_table
     ldr r2, =(TTBR_IRGN1 | TTBR_RGN_0 | TTBR_S | TTBR_NOS)
     orr r1, r1, r2
@@ -110,13 +110,22 @@ entry_el1:
 
 #endif
 
-	dsb	nsh
-	isb
+    dsb	nsh
+    isb
 
     cmp r0, #0
     bne 1f
 
-    ldr r11, =__bss_start 
+#ifdef MEM_NON_UNIFIED
+    /* Copy data from RX to RWX */
+    ldr r7,  =__data_load_start         // LMA start
+    ldr r11, =__data_start              // VMA start
+    ldr r12, =__data_load_end           // LMA end
+
+    bl  copy_data
+#endif
+
+    ldr r11, =__bss_start
     ldr r12, =__bss_end
     bl  clear
 
@@ -158,15 +167,25 @@ wait_flag:
 psci_wake_up:
     b .
 
- .func clear
+.func clear
 clear:
     mov r10, #0
 2:
-	cmp	r11, r12			
-	bge 1f				
-	str	r10, [r11]
+    cmp r11, r12
+    bge 1f
+    str r10, [r11]
     add r11, r11, #4
-	b	2b				
+    b   2b
 1:
-	bx lr
+    bx lr
 .endfunc
+
+/* Copies data from r7 to r11 up to the r12 limit */
+.global copy_data
+copy_data:
+1:
+    ldr r8, [r7], #4
+    str r8, [r11], #4
+    cmp r7, r12
+    bne 1b
+    bx lr

--- a/src/drivers/linflexd_uart/inc/linflexd_uart.h
+++ b/src/drivers/linflexd_uart/inc/linflexd_uart.h
@@ -1,0 +1,84 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+#ifndef LINFLEXD_UART_H
+#define LINFLEXD_UART_H
+
+#define LINFLEXD_0_TX_PIN         0U
+#define LINFLEXD_0_RX_PIN         1U
+
+#define LINFLEXD_9_TX_PIN         150U
+#define LINFLEXD_9_RX_PIN         151U
+
+#define LINFLEXD_0_BASE           (0x40170000UL)
+#define LINFLEXD_9_BASE           (0x42980000UL)
+
+#define LINFLEXD_LINCR1_INIT      (1UL << 0UL)
+#define LINFLEXD_LINCR1_SLEEP     (1UL << 1UL)
+
+#define UART_BAUDRATE             (115200U)
+
+#define LINFLEXD_CLKFREQ          (48000000UL)
+#define LINFLEXD_DFLT_OSR         (16UL)
+
+#define LINFLEXD_UARTCR_UART      (1UL << 0UL)
+#define LINFLEXD_UARTCR_WL0       (1UL << 1UL)
+#define LINFLEXD_UARTCR_WL1       (1UL << 7UL)
+#define LINFLEXD_UARTCR_TXEN      (1UL << 4UL)
+#define LINFLEXD_UARTCR_RXEN      (1UL << 5UL)
+
+#define LINFLEXD_UARTSR_RMB       (1UL << 9UL)
+#define LINFLEXD_UARTSR_DRFRFE    (1UL << 2UL)
+#define LINFLEXD_UARTSR_DTFTFF    (1UL << 1UL)
+
+#define LINFLEXD_LINIER_DRIE      (1UL << 2UL)
+
+#define LINFLEXD_LINSR_LINS_MASK  (0xF000U)
+#define LINFLEXD_LINSR_LINS_SHIFT (12U)
+#define LINFLEXD_LINSR_LINS_DRDT  (0x7UL)
+#define LINFLEXD_LINSR_LINS_HRT   (0x8UL)
+
+#ifndef __ASSEMBLER__
+
+#include <stdint.h>
+
+/** LINFLEXD registers */
+struct linflexd {
+    volatile uint32_t lincr1;
+    volatile uint32_t linier;
+    volatile uint32_t linsr;
+    volatile uint32_t linesr;
+    volatile uint32_t uartcr;
+    volatile uint32_t uartsr;
+    volatile uint32_t lintcsr;
+    volatile uint32_t linocr;
+    volatile uint32_t lintocr;
+    volatile uint32_t linfbrr;
+    volatile uint32_t linibrr;
+    volatile uint32_t lincfr;
+    volatile uint32_t lincr2;
+    volatile uint32_t bidr;
+    volatile uint32_t bdrl;
+    volatile uint32_t bdrm;
+    const uint8_t reserved_0[12];
+    volatile uint32_t gcr;
+    volatile uint32_t uartpto;
+    volatile uint32_t uartcto;
+    volatile uint32_t dmatxe;
+    volatile uint32_t dmarxe;
+};
+
+/** Public LINFLEXD UART interfaces */
+
+void linflexd_uart_enable(volatile struct linflexd * ptr_uart);
+void linflexd_uart_init(volatile struct linflexd * ptr_uart);
+uint8_t linflexd_uart_getc(volatile struct linflexd * ptr_uart);
+void linflexd_uart_putc(volatile struct linflexd * ptr_uart, int8_t c);
+void linflexd_uart_puts(volatile struct linflexd * ptr_uart, const char *s);
+void linflexd_uart_rxirq(volatile struct linflexd * uart);
+void linflexd_uart_clear_rxirq(volatile struct linflexd * uart);
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* LINFLEXD_UART_H */

--- a/src/drivers/linflexd_uart/linflexd_uart.c
+++ b/src/drivers/linflexd_uart/linflexd_uart.c
@@ -1,0 +1,97 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <linflexd_uart.h>
+
+void linflexd_uart_enable(volatile struct linflexd * uart)
+{
+    /* Request normal mode */
+    uart->lincr1 &= ~(LINFLEXD_LINCR1_SLEEP | LINFLEXD_LINCR1_INIT);
+}
+
+static void uart_set_baudrate(volatile struct linflexd* uart)
+{
+    uint32_t ibr;
+
+    /* Compute the value for the integer baudrate */
+    ibr = LINFLEXD_CLKFREQ / (UART_BAUDRATE * LINFLEXD_DFLT_OSR);
+
+    /* Write the computed ibr */
+    uart->linibrr = ibr;
+}
+
+void linflexd_uart_init(volatile struct linflexd * uart)
+{
+    /* Request init mode */
+    uart->lincr1 = (uart->lincr1 & ~(LINFLEXD_LINCR1_SLEEP)) | LINFLEXD_LINCR1_INIT;
+
+    /* Setup UART mode */
+    uart->uartcr = (LINFLEXD_UARTCR_UART);
+
+    /* Setup uart with the following configuration
+     * word length -> 8 Bits
+     * no parity
+     * buffer mode
+     * 115200
+     * Tx and Rx mode
+     */
+    uart->uartcr &= ~(1<<2);
+    uart->uartcr |= LINFLEXD_UARTCR_WL0 | LINFLEXD_UARTCR_TXEN | LINFLEXD_UARTCR_RXEN;
+
+    /* Set the baud rate */
+    uart_set_baudrate(uart);
+
+    /* Sanitize tx empty flag */
+    uart->uartsr |= LINFLEXD_UARTSR_DTFTFF;
+}
+
+void linflexd_uart_rxirq(volatile struct linflexd * uart)
+{
+    /* Enable data transmitted interrupt */
+    uart->linier |= LINFLEXD_LINIER_DRIE;
+}
+
+void linflexd_uart_clear_rxirq(volatile struct linflexd * uart)
+{
+    /* Clear the receive buffer full flag */
+    uart->uartsr |= LINFLEXD_UARTSR_RMB;
+}
+
+uint8_t linflexd_uart_getc(volatile struct linflexd * uart){
+
+    uint8_t data = 0;
+
+    while ((uart->uartsr & LINFLEXD_UARTSR_RMB) == 0u) {
+    /* wait for receive buffer full */
+    }
+
+    data = uart->bdrm & (0xFF);
+
+    linflexd_uart_clear_rxirq(uart);
+
+    return data;
+}
+
+void linflexd_uart_putc(volatile struct linflexd * uart, int8_t c)
+{
+    uint32_t reg_val;
+
+    uart->uartcr |= LINFLEXD_UARTCR_TXEN;
+
+    do {
+        reg_val = (uart->linsr & LINFLEXD_LINSR_LINS_MASK) >> LINFLEXD_LINSR_LINS_SHIFT;
+    } while (reg_val == LINFLEXD_LINSR_LINS_DRDT || reg_val == LINFLEXD_LINSR_LINS_HRT);
+
+    uart->bdrl = (uint32_t)c;
+
+}
+
+void linflexd_uart_puts(volatile struct linflexd * uart, const char *s)
+{
+    while (*s)
+    {
+        linflexd_uart_putc(uart,*s++);
+    }
+}

--- a/src/drivers/linflexd_uart/sources.mk
+++ b/src/drivers/linflexd_uart/sources.mk
@@ -1,0 +1,2 @@
+driver_c_srcs+=linflexd_uart/linflexd_uart.c
+driver_s_srcs+=

--- a/src/platform/s32z270/inc/plat.h
+++ b/src/platform/s32z270/inc/plat.h
@@ -1,0 +1,41 @@
+#ifndef PLAT_H
+#define PLAT_H
+
+#include <linflexd_uart.h>
+
+/* CRAM1 (1MiB) */
+#define PLAT_RO_MEM_BASE 0x32200000
+#define PLAT_RO_MEM_SIZE 0x100000
+
+/* DRAM1 (256KiB) */
+#define PLAT_RW_MEM_BASE 0x317C0000
+#define PLAT_RW_MEM_SIZE 0x40000
+
+#define PLAT_STACKHEAP_SIZE 0x800 // 2KiB
+
+#define PLAT_GENERIC_TIMER_CNTCTL_BASE (0x76200000)
+
+#define PLAT_GICD_BASE_ADDR (0x47800000)
+#define PLAT_GICR_BASE_ADDR (0x47900000)
+
+#define UART0   //FTDI UART (USB IS UART9)
+
+#ifdef UART0
+#define PLAT_UART_ADDR  LINFLEXD_0_BASE
+#define UART_IRQ_ID     244 //LINFLEXD_0
+#define UART_TX_PIN     (LINFLEXD_0_TX_PIN)
+#define UART_RX_PIN     (LINFLEXD_0_RX_PIN)
+#else //UART9
+#define PLAT_UART_ADDR  LINFLEXD_9_BASE
+#define UART_IRQ_ID     253 //LINFLEXD_9
+#define UART_TX_PIN     (LINFLEXD_9_TX_PIN)
+#define UART_RX_PIN     (LINFLEXD_9_RX_PIN)
+#endif
+
+#ifndef __ASSEMBLER__
+
+void plat_init(void);
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* PLAT_H */

--- a/src/platform/s32z270/plat.mk
+++ b/src/platform/s32z270/plat.mk
@@ -1,0 +1,6 @@
+ARCH:=armv8
+GIC_VERSION:=GICV3
+drivers:=linflexd_uart
+MPU:=y
+ARCH_SUB:=aarch32
+MEM_MODEL:=NON_UNIFIED

--- a/src/platform/s32z270/s32z270.c
+++ b/src/platform/s32z270/s32z270.c
@@ -1,0 +1,30 @@
+#include <plat.h>
+#include <linflexd_uart.h>
+
+volatile struct linflexd *uart  =  (volatile struct linflexd *)PLAT_UART_ADDR;
+
+void uart_init(void)
+{
+    linflexd_uart_init(uart);
+    linflexd_uart_enable(uart);
+}
+
+void uart_putc(char c)
+{
+    linflexd_uart_putc(uart, c);
+}
+
+char uart_getchar(void)
+{
+    return linflexd_uart_getc(uart);
+}
+
+void uart_enable_rxirq(void)
+{
+    linflexd_uart_rxirq(uart);
+}
+
+void uart_clear_rxirq(void)
+{
+    linflexd_uart_clear_rxirq(uart);
+}

--- a/src/platform/s32z270/sources.mk
+++ b/src/platform/s32z270/sources.mk
@@ -1,0 +1,2 @@
+plat_c_srcs:=s32z270.c
+plat_s_srcs:=


### PR DESCRIPTION
This pull request adds support for the S32Z270 platform. It also modifies the ARMv8 AARCH32 startup code to support non-unified memory models by conditionally copying data sections at boot. Fixed a type casting issue in system register read macros to ensure correct behavior on 32-bit platforms.