### PR TITLE
ref(main-irq): change IRQ init location inside main

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -65,13 +65,14 @@ void main(void){
         irq_enable(TIMER_IRQ_ID);
         irq_set_prio(TIMER_IRQ_ID, TIMER_IRQ_PRIO);
 
+        irq_enable(UART_IRQ_ID);
+        irq_set_prio(UART_IRQ_ID, UART_IRQ_PRIO);
+
         timer_enable();
 
         master_done = true;
     }
 
-    irq_enable(UART_IRQ_ID);
-    irq_set_prio(UART_IRQ_ID, UART_IRQ_PRIO);
     irq_enable(IPI_IRQ_ID);
     irq_set_prio(IPI_IRQ_ID, UART_IRQ_PRIO);
 

--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,6 @@ void main(void){
 
         irq_set_handler(UART_IRQ_ID, uart_rx_handler);
         irq_set_handler(TIMER_IRQ_ID, timer_handler);
-        irq_set_handler(IPI_IRQ_ID, ipi_handler);
 
         uart_enable_rxirq();
 
@@ -72,6 +71,8 @@ void main(void){
 
         master_done = true;
     }
+
+    irq_set_handler(IPI_IRQ_ID, ipi_handler);
 
     irq_enable(IPI_IRQ_ID);
     irq_set_prio(IPI_IRQ_ID, UART_IRQ_PRIO);


### PR DESCRIPTION
## PR Description

This PR moves the place of UART IRQ init and the IPI handler installation.

- The UART IRQ init is now done by the cpu master, since only a single core will receive the interrupt. Furthermore, this is a probelm for TC4 since multiple cores enabling and setting an interrupt priority causes errors.

- The IPI handler installation is now done by all cores. I tested on QEMUS and all seem to be working. This was done because TC4 needs to have all cores installing their own handlers. 
