### PR TITLE
Add support for test framework

### DIFF
--- a/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
+++ b/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
@@ -105,6 +105,17 @@ SYSREG_GEN_ACCESSORS(icc_ctlr_el1, 0, c12, c12, 4);
 SYSREG_GEN_ACCESSORS(icc_igrpen1_el1, 0, c12, c12, 7);
 SYSREG_GEN_ACCESSORS_64(icc_sgi1r_el1, 0, c12);
 
+SYSREG_GEN_ACCESSORS(pmcntenclr_el0, 0, c9, c12, 2)
+SYSREG_GEN_ACCESSORS(pmcntenset_el0, 0, c9, c12, 1)
+SYSREG_GEN_ACCESSORS(pmselr_el0, 0, c9, c12, 5)
+SYSREG_GEN_ACCESSORS(pmxevtyper_el0, 0, c9, c13, 1)
+SYSREG_GEN_ACCESSORS(pmxevcntr_el0, 0, c9, c13, 2)
+SYSREG_GEN_ACCESSORS(pmintenset_el1, 0, c9, c14, 1)
+SYSREG_GEN_ACCESSORS(pmintenclr_el1, 0, c9, c14, 2)
+SYSREG_GEN_ACCESSORS(pmovsclr_el0, 0, c9, c12, 3)
+SYSREG_GEN_ACCESSORS(pmccfiltr_el0, 0, c14, c15, 7)
+SYSREG_GEN_ACCESSORS(pmccntr_el0, 0, c9, c13, 0)
+
 SYSREG_GEN_ACCESSORS(dccivac, 0, c7, c14, 1);
 static inline void arm_dc_civac(uintptr_t cache_addr)
 {

--- a/src/arch/armv8/aarch32/start.S
+++ b/src/arch/armv8/aarch32/start.S
@@ -37,14 +37,20 @@ _start:
     mcr p15, 4, r0, c12, c9, 5 // icc_hsre
 #endif
 
-#if defined(MPU) && defined(PLAT_GENERIC_TIMER_CNTCTL_BASE)
+#if defined(MPU)
+#if defined(PLAT_GENERIC_TIMER_FIXED_FREQ)
+    ldr r1, =PLAT_GENERIC_TIMER_FIXED_FREQ
+#elif defined(PLAT_GENERIC_TIMER_CNTCTL_BASE)
     ldr r0, =PLAT_GENERIC_TIMER_CNTCTL_BASE
     ldr r1, [r0, #GENERIC_TIMER_CNTCTL_CNTCR_OFFSET]
     orr r1, r1, #GENERIC_TIMER_CNTCTL_CNTCR_EN
     str r1, [r0, #GENERIC_TIMER_CNTCTL_CNTCR_OFFSET]
     ldr r1, [r0, #GENERIC_TIMER_CNTCTL_CNTDIF0_OFFSET]
-    mcr p15, 0, r1, c14, c0, 0 // cntfrq
+#else
+    #error "No generic timer frequency source defined"
 #endif
+    mcr p15, 0, r1, c14, c0, 0 // cntfrq
+#endif  /* defined(MPU) */
 
     mrs r0, cpsr
     mov r1, #MODE_SVC

--- a/src/arch/armv8/aarch64/inc/arch/subarch/sysregs.h
+++ b/src/arch/armv8/aarch64/inc/arch/subarch/sysregs.h
@@ -85,6 +85,13 @@ SYSREG_GEN_ACCESSORS(icc_rpr_el1);
 SYSREG_GEN_ACCESSORS(icc_ctlr_el1);
 SYSREG_GEN_ACCESSORS(icc_igrpen1_el1);
 SYSREG_GEN_ACCESSORS(icc_sgi1r_el1);
+SYSREG_GEN_ACCESSORS(pmcntenclr_el0);
+SYSREG_GEN_ACCESSORS(pmcntenset_el0);
+SYSREG_GEN_ACCESSORS(pmselr_el0);
+SYSREG_GEN_ACCESSORS(pmxevtyper_el0);
+SYSREG_GEN_ACCESSORS(pmxevcntr_el0);
+SYSREG_GEN_ACCESSORS(pmccntr_el0);
+SYSREG_GEN_ACCESSORS(pmccfiltr_el0);
 
 static inline void arm_dc_civac(uintptr_t cache_addr)
 {

--- a/src/arch/armv8/aarch64/start.S
+++ b/src/arch/armv8/aarch64/start.S
@@ -46,14 +46,20 @@ _start:
     msr icc_sre_el2, x1
 #endif
 
-#ifdef MPU
+#if defined(MPU)
+#if defined(PLAT_GENERIC_TIMER_FIXED_FREQ)
+    ldr x2, =PLAT_GENERIC_TIMER_FIXED_FREQ
+#elif defined(PLAT_GENERIC_TIMER_CNTCTL_BASE)
     ldr x1, =PLAT_GENERIC_TIMER_CNTCTL_BASE
     ldr w2, [x1, GENERIC_TIMER_CNTCTL_CNTCR_OFFSET]
     orr w2, w2, GENERIC_TIMER_CNTCTL_CNTCR_EN
     str w2, [x1, GENERIC_TIMER_CNTCTL_CNTCR_OFFSET]
     ldr w2, [x1, GENERIC_TIMER_CNTCTL_CNTDIF0_OFFSET]
-    msr cntfrq_el0, x2
+#else
+    #error "No generic timer frequency source defined"
 #endif
+    msr cntfrq_el0, x2
+#endif  /* defined(MPU) */
 
     adr x1, _exception_vector
     msr	VBAR_EL2, x1

--- a/src/arch/armv8/inc/arch/cycle_counter.h
+++ b/src/arch/armv8/inc/arch/cycle_counter.h
@@ -1,0 +1,45 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef ARCH_CYCLE_COUNTER_H_
+#define ARCH_CYCLE_COUNTER_H_
+
+#include <core.h>
+#include <sysregs.h>
+
+#define PMCNTENSET_C  (1 << 31)
+#define PMCCFILTR_NSH (1 << 27)
+#define PMCR_C        (1 << 2)
+#define PMCR_P        (1 << 1)
+#define PMCR_E        (1 << 0)
+
+static inline uint64_t arch_cc_get_count(void)
+{
+    uint64_t val = sysreg_pmccntr_el0_read();
+    return val;
+}
+
+static inline void arch_cc_enable(void)
+{
+    sysreg_pmccfiltr_el0_write(PMCCFILTR_NSH);
+    sysreg_pmcntenset_el0_write(PMCNTENSET_C);
+}
+
+static inline void arch_cc_reset_count(void)
+{
+    sysreg_pmcr_el0_write(sysreg_pmcr_el0_read() | PMCR_C);
+}
+
+static inline void arch_cc_start(void)
+{
+    sysreg_pmcr_el0_write(sysreg_pmcr_el0_read() | PMCR_E);
+}
+
+static inline void arch_cc_stop(void)
+{
+    sysreg_pmcr_el0_write(sysreg_pmcr_el0_read() & ~PMCR_E);
+}
+
+#endif /* ARCH_CYCLE_COUNTER_H_ */

--- a/src/arch/armv8/inc/arch/hypercall.h
+++ b/src/arch/armv8/inc/arch/hypercall.h
@@ -1,0 +1,22 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_HYPERCALL_H__
+#define __ARCH_HYPERCALL_H__
+
+#define SMCC32_FID_VND_HYP_SRVC 0x86000000
+
+static uint64_t bao_hypercall(uint64_t hc_id, uint64_t arg1, uint64_t arg2, uint64_t arg3)
+{
+    register uint64_t r0 asm("x0") = SMCC32_FID_VND_HYP_SRVC | hc_id;
+    register uint64_t r1 asm("x1") = arg1;
+    register uint64_t r2 asm("x2") = arg2;
+    register uint64_t r3 asm("x3") = arg3;
+
+    asm volatile("hvc   #0\n" : "=r"(r0) : "r"(r0), "r"(r1), "r"(r2), "r"(r3));
+    return r0;
+}
+
+#endif /* __ARCH_HYPERCALL_H__ */

--- a/src/arch/armv8/inc/arch/timer.h
+++ b/src/arch/armv8/inc/arch/timer.h
@@ -34,10 +34,16 @@ static inline void timer_enable(void)
     sysreg_cntv_ctl_el0_write(CNTV_CTL_ENABLE);
 }
 
-static inline void timer_set(uint64_t n)
+static inline void timer_disable()
+{
+    sysreg_cntv_ctl_el0_write(0);
+}
+
+static uint64_t timer_set(uint64_t n)
 {
     uint64_t current = sysreg_cntvct_el0_read();
     sysreg_cntv_cval_el0_write(current + n);
+    return current + n;
 }
 
 static inline uint64_t timer_get()

--- a/src/arch/rh850/cycle_counter.c
+++ b/src/arch/rh850/cycle_counter.c
@@ -1,0 +1,15 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+#include <stdint.h>
+
+uint64_t time = 0;
+
+__attribute__((weak)) void cc_enable_impl(void)
+{
+    /* When running as a guest, we assume the cycle counter is always enabled. When running the
+       baremetal standalone the cc needs explicit enabling, which can be achieved by overriding
+       this function.
+     */
+}

--- a/src/arch/rh850/inc/arch/cycle_counter.h
+++ b/src/arch/rh850/inc/arch/cycle_counter.h
@@ -1,0 +1,56 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef ARCH_CYCLE_COUNTER_H_
+#define ARCH_CYCLE_COUNTER_H_
+
+#include <util.h>
+#include <stdint.h>
+#include <srs.h>
+#include <plat.h>
+
+extern uint64_t time;
+
+void cc_enable_impl(void) __attribute__((weak));
+
+static inline uint64_t read_tscount64(void)
+{
+    uint32_t hi1, lo, hi2;
+
+    do {
+        hi1 = srs_tscounth_read();
+        lo = srs_tscountl_read();
+        hi2 = srs_tscounth_read();
+    } while (hi1 != hi2);
+
+    return ((uint64_t)hi2 << 32) | lo;
+}
+
+static inline uint64_t arch_cc_get_count(void)
+{
+    return (unsigned long)read_tscount64() - time;
+}
+
+static inline void arch_cc_enable(void)
+{
+    cc_enable_impl();
+}
+
+static inline void arch_cc_reset_count(void)
+{
+    time = read_tscount64();
+}
+
+static inline void arch_cc_start(void)
+{
+    /* Nothing to do */
+}
+
+static inline void arch_cc_stop(void)
+{
+    /* Nothing to do */
+}
+
+#endif /* ARCH_CYCLE_COUNTER_H_ */

--- a/src/arch/rh850/inc/arch/hypercall.h
+++ b/src/arch/rh850/inc/arch/hypercall.h
@@ -1,0 +1,21 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_HYPERCALL_H__
+#define __ARCH_HYPERCALL_H__
+
+static inline uint32_t bao_hypercall(unsigned long id, unsigned long arg1, unsigned long arg2)
+{
+    register unsigned long r6 asm("r6") = id;
+    register unsigned long r7 asm("r7") = arg1;
+    register unsigned long r8 asm("r8") = arg2;
+    register unsigned long r10 asm("r10");
+
+    __asm__ volatile("hvtrap 0" : "=r"(r10) : "r"(r6), "r"(r7), "r"(r8));
+
+    return (uint32_t)r10;
+}
+
+#endif /* __ARCH_HYPERCALL_H__ */

--- a/src/arch/rh850/inc/arch/timer.h
+++ b/src/arch/rh850/inc/arch/timer.h
@@ -11,6 +11,6 @@
 
 void timer_enable();
 uint64_t timer_get();
-void timer_set(uint64_t n);
+uint64_t timer_set(uint64_t n);
 
 #endif /* ARCH_TIMER_H */

--- a/src/arch/rh850/sources.mk
+++ b/src/arch/rh850/sources.mk
@@ -1,5 +1,5 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-arch_c_srcs:= init.c intc.c irq.c
+arch_c_srcs:= init.c intc.c irq.c cycle_counter.c
 arch_s_srcs:= start.S exceptions.S

--- a/src/arch/riscv/inc/arch/cycle_counter.h
+++ b/src/arch/riscv/inc/arch/cycle_counter.h
@@ -1,0 +1,37 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef ARCH_CYCLE_COUNTER_H_
+#define ARCH_CYCLE_COUNTER_H_
+
+#include <util.h>
+
+static inline uint64_t arch_cc_get_count(void)
+{
+    NOT_IMPLEMENTED();
+    return 0;
+}
+
+static inline void arch_cc_enable(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+static inline void arch_cc_reset_count(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+static inline void arch_cc_start(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+static inline void arch_cc_stop(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+#endif /* ARCH_CYCLE_COUNTER_H_ */

--- a/src/arch/riscv/inc/arch/hypercall.h
+++ b/src/arch/riscv/inc/arch/hypercall.h
@@ -1,0 +1,33 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_HYPERCALL_H__
+#define __ARCH_HYPERCALL_H__
+
+#include <sbi.h>
+
+#define SBI_EXTID_BAO (0x08000ba0)
+
+static inline struct sbiret bao_hypercall(unsigned long eid, unsigned long fid, unsigned long a0,
+    unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4, unsigned long a5)
+{
+    register unsigned long _a0 __asm__("a0") = a0;
+    register unsigned long _a1 __asm__("a1") = a1;
+    register unsigned long _a2 __asm__("a2") = a2;
+    register unsigned long _a3 __asm__("a3") = a3;
+    register unsigned long _a4 __asm__("a4") = a4;
+    register unsigned long _a5 __asm__("a5") = a5;
+    register unsigned long _a6 __asm__("a6") = fid;
+    register unsigned long _a7 __asm__("a7") = eid;
+
+    __asm__ volatile("ecall" : "+r"(_a0), "+r"(_a1) : "r"(_a2), "r"(_a3), "r"(_a4), "r"(_a5),
+                     "r"(_a6), "r"(_a7) : "memory");
+
+    struct sbiret ret = { .error = (long)_a0, .value = (long)_a1 };
+
+    return ret;
+}
+
+#endif /* __ARCH_HYPERCALL_H__ */

--- a/src/arch/riscv/inc/arch/timer.h
+++ b/src/arch/riscv/inc/arch/timer.h
@@ -20,7 +20,7 @@ uint64_t timer_get()
     return csrs_time_read();
 }
 
-void timer_set(uint64_t n)
+uint64_t timer_set(uint64_t n)
 {
     uint64_t next_tick = timer_get() + n;
 
@@ -29,6 +29,8 @@ void timer_set(uint64_t n)
     } else {
         sbi_set_timer(next_tick);
     }
+
+    return next_tick;
 }
 
 #endif /* ARCH_TIMER_H */

--- a/src/arch/tricore/inc/arch/cycle_counter.h
+++ b/src/arch/tricore/inc/arch/cycle_counter.h
@@ -1,0 +1,35 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef ARCH_CYCLE_COUNTER_H_
+#define ARCH_CYCLE_COUNTER_H_
+
+static inline uint64_t arch_cc_get_count(void)
+{
+    NOT_IMPLEMENTED();
+    return 0;
+}
+
+static inline void arch_cc_enable(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+static inline void arch_cc_reset_count(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+static inline void arch_cc_start(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+static inline void arch_cc_stop(void)
+{
+    NOT_IMPLEMENTED();
+}
+
+#endif /* ARCH_CYCLE_COUNTER_H_ */

--- a/src/arch/tricore/inc/arch/hypercall.h
+++ b/src/arch/tricore/inc/arch/hypercall.h
@@ -1,0 +1,16 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_HYPERCALL_H__
+#define __ARCH_HYPERCALL_H__
+
+static inline uint32_t bao_hypercall(unsigned long id)
+{
+    NOT_IMPLEMENTED();
+
+    return 0;
+}
+
+#endif /* __ARCH_HYPERCALL_H__ */

--- a/src/arch/tricore/timer.c
+++ b/src/arch/tricore/timer.c
@@ -59,7 +59,7 @@ uint64_t timer_get()
     return *ABS;
 }
 
-void timer_set(uint64_t period_us)
+uint64_t timer_set(uint64_t period_us)
 {
     volatile unsigned long* CMP0 = STM_CMP0_ADDR;
     volatile unsigned long long* ABS = STM_ABS_ADDR;
@@ -79,5 +79,7 @@ void timer_set(uint64_t period_us)
         uint32_t next = current + (uint32_t)period_us;
 
         *CMP0 = next;
+
+        return next;
     }
 }

--- a/src/core/inc/cycle_counter.h
+++ b/src/core/inc/cycle_counter.h
@@ -1,0 +1,32 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef CYCLE_COUNTER_H_
+#define CYCLE_COUNTER_H_
+
+#include <core.h>
+#include <arch/cycle_counter.h>
+
+static inline uint64_t cc_get_count()
+{
+    return arch_cc_get_count();
+}
+
+static inline void cc_reset_count()
+{
+    arch_cc_reset_count();
+}
+
+static inline void cc_enable()
+{
+    arch_cc_enable();
+}
+
+static inline void cc_start()
+{
+    arch_cc_start();
+}
+
+#endif /* CYCLE_COUNTER_H_ */

--- a/src/core/inc/hypercall.h
+++ b/src/core/inc/hypercall.h
@@ -1,0 +1,14 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef HYPERCALL_H
+#define HYPERCALL_H
+
+#include <arch/hypercall.h>
+
+#define BAO_YIELD_HYPCALL_ID       3
+#define BAO_CACHE_FLUSH_HYPCALL_ID 4
+
+#endif /* HYPERCALL_H */

--- a/src/core/inc/timer.h
+++ b/src/core/inc/timer.h
@@ -14,7 +14,7 @@
 #define TIME_S(s)   (TIME_MS((s) * 1000ull))
 
 uint64_t timer_get();
-void timer_set(uint64_t n);
+uint64_t timer_set(uint64_t n);
 
 static inline void timer_wait(uint64_t n)
 {

--- a/src/core/inc/util.h
+++ b/src/core/inc/util.h
@@ -17,4 +17,16 @@
 #define __DEFINED(VALUE)                ___DEFINED(VALUE true, false)
 #define ___DEFINED(IGNORE, RESULT, ...) (RESULT)
 
+#define INFO(...)                       printf("BAO-BAREMETAL INFO: " __VA_ARGS__);
+
+#define WARNING(...)                    printf("BAO-BAREMETAL WARNING: " __VA_ARGS__);
+
+#define ERROR(...)                               \
+    printf("BAO-BAREMETAL ERROR: " __VA_ARGS__); \
+    while (true) {                               \
+        wfi();                                   \
+    };
+
+#define NOT_IMPLEMENTED() ERROR("%s not implemented\n", __func__)
+
 #endif /* UTIL_H */

--- a/src/drivers/rh850-u2a16_ostm/inc/rh850-u2a16_ostm.h
+++ b/src/drivers/rh850-u2a16_ostm/inc/rh850-u2a16_ostm.h
@@ -43,7 +43,7 @@ static inline uint64_t rh850_u2a16_OSTMn_get(volatile struct rh850_u2a16_OSTMn* 
     return timer->OSTMnCNT;
 }
 
-static inline void rh850_u2a16_OSTMn_set(volatile struct rh850_u2a16_OSTMn* timer, uint64_t n)
+static inline uint64_t rh850_u2a16_OSTMn_set(volatile struct rh850_u2a16_OSTMn* timer, uint64_t n)
 {
     // Stop
     timer->OSTMnTT = 0x01;
@@ -51,5 +51,7 @@ static inline void rh850_u2a16_OSTMn_set(volatile struct rh850_u2a16_OSTMn* time
     timer->OSTMnCMP = n;
     // Start
     timer->OSTMnTS |= (0x01);
+
+    return n;
 }
 #endif /* RH850_U2A16_OSTM_H */

--- a/src/platform/rh850-u2a16/inc/plat.h
+++ b/src/platform/rh850-u2a16/inc/plat.h
@@ -23,7 +23,6 @@
 #define UART_IRQ_ID         (438)          // RLIN35 Receive completion interrupt
 
 #define PLAT_OSTM0_BASE     (0xFFBF0000UL) // OSTM0
-#define PLAT_CLK_CPU        (400000000UL)  // 400 MHz. This value depends on CKDIVMD OPTION BYTE.
 // OSTM0 timer interrupt
 #define TIMER_IRQ_ID        (199UL)
 
@@ -41,5 +40,7 @@
 
 // OSTM use CLK_HSB
 #define TIMER_FREQ          PLAT_CLK_HSB
+
+#define PLAT_CPU_FREQ       (400000000UL) // 400 MHz. This value depends on CKDIVMD OPTION BYTE.
 
 #endif

--- a/src/platform/rh850-u2a16/u2a16.c
+++ b/src/platform/rh850-u2a16/u2a16.c
@@ -47,7 +47,7 @@ uint64_t timer_get()
     return rh850_u2a16_OSTMn_get(timer);
 }
 
-void timer_set(uint64_t n)
+uint64_t timer_set(uint64_t n)
 {
-    rh850_u2a16_OSTMn_set(timer, n);
+    return rh850_u2a16_OSTMn_set(timer, n);
 }

--- a/src/platform/s32z270/inc/plat.h
+++ b/src/platform/s32z270/inc/plat.h
@@ -41,7 +41,9 @@
 #define UART_RX_PIN    (LINFLEXD_9_RX_PIN)
 #endif
 
-#define UART_CLKFREQ (48000000UL)
+#define UART_CLKFREQ  (48000000UL)
+
+#define PLAT_CPU_FREQ (1000000000UL) // 1GHz
 
 #ifndef __ASSEMBLER__
 

--- a/src/platform/s32z270/inc/plat.h
+++ b/src/platform/s32z270/inc/plat.h
@@ -9,23 +9,25 @@
 #include <linflexd_uart.h>
 
 /* CRAM1 (1MiB) */
-#define PLAT_RO_MEM_BASE               0x32200000
-#define PLAT_RO_MEM_SIZE               0x100000
+#define PLAT_RO_MEM_BASE    0x32200000
+#define PLAT_RO_MEM_SIZE    0x100000
 /* DRAM1 (256KiB) */
-#define PLAT_RW_MEM_BASE               0x317C0000
-#define PLAT_RW_MEM_SIZE               0x40000
+#define PLAT_RW_MEM_BASE    0x317C0000
+#define PLAT_RW_MEM_SIZE    0x40000
 /* Device Memory */
-#define PLAT_DEV_MEM_BASE              0x40000000
-#define PLAT_DEV_MEM_SIZE              0x37000000
+#define PLAT_DEV_MEM_BASE   0x40000000
+#define PLAT_DEV_MEM_SIZE   0x37000000
 
-#define PLAT_STACKHEAP_SIZE            0x800 // 2KiB
+#define PLAT_STACKHEAP_SIZE 0x800                 // 2KiB
 
-#define PLAT_GENERIC_TIMER_CNTCTL_BASE (0x76200000)
+#ifndef PLAT_GENERIC_TIMER_FIXED_FREQ
+#define PLAT_GENERIC_TIMER_FIXED_FREQ (8000000UL) // 8MHz
+#endif
 
-#define PLAT_GICD_BASE_ADDR            (0x47800000)
-#define PLAT_GICR_BASE_ADDR            (0x47900000)
+#define PLAT_GICD_BASE_ADDR (0x47800000)
+#define PLAT_GICR_BASE_ADDR (0x47900000)
 
-#define UART0                          // FTDI UART (USB IS UART9)
+#define UART0               // FTDI UART (USB IS UART9)
 
 #ifdef UART0
 #define PLAT_UART_ADDR LINFLEXD_0_BASE

--- a/src/platform/zcu104/inc/plat.h
+++ b/src/platform/zcu104/inc/plat.h
@@ -12,4 +12,6 @@
 #define PLAT_UART_ADDR 0xFF000000
 #define UART_IRQ_ID    53
 
+#define PLAT_CPU_FREQ  (1200000000UL) // 1.2GHz
+
 #endif


### PR DESCRIPTION
This PR introduces several changes to give support for the test framework, as well as, some fixes related to the initialization of the generic timer in aarch32. 

Main changes:
- `timer_set`API now returns the next tick
- Added support for the a cycle counter (arch: pmu on armv8) 
- Added support for Bao hypercalls
- Refactored timer initialization to comply with Cortex-R52 implementation-defined timer 