### PR TITLE
fix(aarch32): add branch with link to plat_early_init

### DIFF
--- a/src/arch/armv8/aarch32/start.S
+++ b/src/arch/armv8/aarch32/start.S
@@ -25,7 +25,7 @@ _start:
 1:
     /* This is a weak symbol needed for early platform initialization routines when the baremetal
        guest is used standalone. If not defined, the compiler replaces the branch with a NOP */
-    b plat_early_init
+    bl plat_early_init
 
 #if GIC_VERSION == GICV3
     mrc p15, 4, r0, c12, c9, 5 // icc_hsre


### PR DESCRIPTION
Missed in PR #28 