### PR TITLE
feat(github): add stale workflows

### DIFF
--- a/.github/workflows/stale-contrib.yml
+++ b/.github/workflows/stale-contrib.yml
@@ -1,0 +1,138 @@
+# ============================================================
+# stale-contrib.yml
+#
+# Tracks staleness from the CONTRIBUTOR side:
+#   - Warns contributor after 30 days of no reply to a reviewer
+#   - Closes after 30 more days of silence
+#   - Exempts items still awaiting a reviewer (covered by stale-reviewer.yml)
+#
+# Label contract (create these in your repo):
+#   awaiting-contributor  – set by stale-reviewer.yml or manually by reviewers
+#   awaiting-reviewer     – set by stale-reviewer.yml or manually by contributors
+#   stale-contributor     – set by this workflow
+#   stale-reviewer        – set by stale-reviewer.yml
+#   pinned                – opt-out of all stale automation
+#   no-stale              – opt-out of all stale automation
+# ============================================================
+
+name: "Stale PR & Issue Checker – Contributor"
+
+on:
+  schedule:
+    - cron: "0 2 * * *"     # Runs every day at 02:00 UTC
+  workflow_dispatch:        # allow manual trigger for testing
+
+permissions:
+  pull-requests: write # to comment on stale pull requests
+  issues: write        # to comment on stale issues
+
+jobs:
+  # ----------------------------------------------------------
+  # JOB 1 – Issues where the contributor hasn't replied
+  # ----------------------------------------------------------
+  stale-contributor-issues:
+    name: "Issues – warn contributor"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Only process issues that have been explicitly flagged as
+          # awaiting the contributor's response by a reviewer.
+          only-issue-labels: "awaiting-contributor"
+
+          # 30 days with no activity → mark as stale
+          days-before-issue-stale: 30
+          # 7 more days → close
+          days-before-issue-close: 30
+
+          # Never touch PRs in this job
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          stale-issue-label: "stale-contributor"
+          close-issue-label: "closed-for-inactivity"
+          close-issue-reason: "not_planned"
+
+          # Remove the awaiting label when unstaled (contributor replied)
+          labels-to-remove-when-unstale: "stale-contributor"
+
+          stale-issue-message: |
+            This issue has been waiting for the author's response to maintainer feedback for **30
+            days**. Please reply within the next **30 days** or this issue will be automatically
+            closed as inactive.
+
+            You can always re-open it or continue the conversation after it is closed. If you need
+            more time, just leave a quick comment and the timer resets!
+
+            > _Automated message from the stale-contributor workflow._
+
+          close-issue-message: |
+            This issue has been **automatically closed** due to 30+30 days of inactivity after
+            reviewer feedback was provided.
+
+            No worries — you're welcome to re-open it at any time if you would like to continue the
+            discussion. Please make sure to address the reviewer's comments when you do.
+
+            > _Automated message from the stale-contributor workflow._
+
+          # Global exemptions
+          exempt-issue-labels: "awaiting-reviewer"
+          exempt-all-issue-milestones: true  # milestone = planned work, never stale
+          exempt-draft-pr: true
+
+          # Performance / rate-limit safety
+          operations-per-run: 150
+          ascending: true   # process oldest first so long-forgotten items surface first
+
+  # ----------------------------------------------------------
+  # JOB 2 – PRs where the contributor hasn't replied
+  # ----------------------------------------------------------
+  stale-contributor-prs:
+    name: "PRs – warn contributor"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          only-pr-labels: "awaiting-contributor"
+
+          days-before-pr-stale: 30
+          days-before-pr-close: 30
+
+          # Never touch issues in this job
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          stale-pr-label: "stale-contributor"
+          close-pr-label: "closed-for-inactivity"
+
+          labels-to-remove-when-unstale: "stale-contributor"
+
+          stale-pr-message: |
+            This pull request has been awaiting for the author's response to reviewer feedback for
+            **30 days**. Please address the comments within **30 days** or this PR will be
+            automatically closed.
+
+            If you need more time, drop a comment and the clock resets. Closed PRs can always be
+            re-opened.
+
+            > _Automated message from the stale-contributor workflow._
+
+          close-pr-message: |
+            This pull request has been **automatically closed** after 30+30 days of inactivity
+            following reviewer feedback.
+
+            You are welcome to re-open it once the reviewer's comments have been addressed. Thank
+            you for your contribution!
+
+            > _Automated message from the stale-contributor workflow._
+
+          exempt-pr-labels: "awaiting-reviewer"
+          exempt-all-pr-milestones: true
+          exempt-draft-pr: true
+
+          operations-per-run: 150
+          ascending: true

--- a/.github/workflows/stale-reviewer.yml
+++ b/.github/workflows/stale-reviewer.yml
@@ -1,0 +1,282 @@
+# ============================================================
+# stale-reviewer.yml
+#
+# Tracks staleness from the REVIEWER side:
+#   - If a contributor updated an issue/PR and the reviewer
+#     hasn't replied within 15 days → nudge reviewer
+#   - Uses label-based routing so only the right items are touched
+#
+# This workflow runs on SCHEDULE (daily) AND on issue/PR events
+# so the "awaiting-reviewer" label is applied in near-real-time
+# when a contributor comments.
+#
+# Label contract (same as stale-contributor.yml):
+#   awaiting-contributor  – reviewer left feedback, waiting on contributor
+#   awaiting-reviewer     – contributor replied, waiting on reviewer
+#   stale-reviewer        – applied when reviewer is overdue
+# ============================================================
+
+name: "Stale PR & Issue Checker – Reviewer"
+
+on:
+  schedule:
+    - cron: "30 2 * * *"    # 30 min after stale-contributor, avoids race
+  workflow_dispatch:        # allow manual trigger for testing
+
+  # ── Real-time label routing ──────────────────────────────
+  # When a contributor comments, remove "awaiting-contributor"
+  # and add "awaiting-reviewer" immediately.
+  issue_comment:
+    types: [created]
+
+  pull_request_review:
+    types: [submitted]
+
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write # to comment on stale pull requests
+  issues: write        # to comment on stale issues
+
+jobs:
+  # ----------------------------------------------------------
+  # JOB 1 – Real-time label routing on comment events
+  #
+  # When a non-bot contributor comments on an item that has
+  # "awaiting-contributor", flip the label to "awaiting-reviewer".
+  # When a reviewer submits a review/comment, flip back.
+  # ----------------------------------------------------------
+  route-labels:
+    name: "Route awaiting labels on activity"
+    runs-on: ubuntu-latest
+    # Only run on event-triggered runs, not schedule
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    steps:
+      - name: "Flip label: contributor replied → awaiting-reviewer"
+        uses: actions/github-script@v8
+        if: |
+          github.event_name == 'issue_comment' &&
+          github.event.sender.type != 'Bot'
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const pr    = context.payload.pull_request;
+            const num   = issue ? issue.number : (pr ? pr.number : null);
+            if (!num) return;
+
+            // Determine if the commenter is a maintainer/reviewer or contributor
+            // We flip labels based on whether this is the issue author replying
+            // vs a reviewer replying.
+            const issueData = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: num,
+            });
+
+            const labels = issueData.data.labels.map(l => l.name);
+            const sender = context.payload.sender.login;
+            const author = issueData.data.user.login;
+
+            console.log(`#${num}: event=${context.payload.action || 'created'} sender=${sender} author=${author} labels=${labels.join(',')}`);
+
+            // If the commenter is the original author (contributor), flip to awaiting-reviewer
+            if (sender === author) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'awaiting-contributor',
+              }).catch(() => {});  // label may already be gone
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                labels: ['awaiting-reviewer'],
+              });
+
+              console.log(`#${num}: contributor replied → set awaiting-reviewer`);
+            }
+
+            // If a reviewer/maintainer replies and label is awaiting-reviewer, flip back
+            if (sender !== author && labels.includes('awaiting-reviewer')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'awaiting-reviewer',
+              }).catch(() => {});
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                labels: ['awaiting-contributor'],
+              });
+
+              console.log(`#${num}: reviewer replied → set awaiting-contributor`);
+            }
+
+            // Also always clear stale-reviewer if anyone comments
+            if (labels.includes('stale-reviewer')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'stale-reviewer',
+              }).catch(() => {});
+            }
+
+      - name: "Flip label: reviewer submitted review → awaiting-contributor"
+        uses: actions/github-script@v8
+        if: |
+          (github.event_name == 'pull_request_review' ||
+           github.event_name == 'pull_request_review_comment') &&
+          github.event.sender.type != 'Bot'
+        with:
+          script: |
+            const num = context.payload.pull_request.number;
+
+            const prData = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              pull_number: num,
+            });
+
+            const labels = prData.data.labels.map(l => l.name);
+            const sender = context.payload.sender.login;
+            const author = prData.data.user.login;
+
+            console.log(`PR #${num}: event=${context.eventName} sender=${sender} author=${author} labels=${labels.join(',')}`);
+
+            if (sender !== author) {
+              // Reviewer commented/reviewed → awaiting-contributor
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'awaiting-reviewer',
+              }).catch(() => {});
+
+              if (!labels.includes('awaiting-contributor')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: num,
+                  labels: ['awaiting-contributor'],
+                });
+              }
+
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'stale-reviewer',
+              }).catch(() => {});
+
+              console.log(`PR #${num}: reviewer reviewed → set awaiting-contributor`);
+            }
+
+            if (sender === author) {
+              // Contributor updated via PR review/review-comment → awaiting-reviewer
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'awaiting-contributor',
+              }).catch(() => {});
+
+              if (!labels.includes('awaiting-reviewer')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: num,
+                  labels: ['awaiting-reviewer'],
+                });
+              }
+
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: num,
+                name: 'stale-reviewer',
+              }).catch(() => {});
+
+              console.log(`PR #${num}: contributor updated review → set awaiting-reviewer`);
+            }
+
+  # ----------------------------------------------------------
+  # JOB 2 – Scheduled: nudge overdue reviewers on Issues
+  # ----------------------------------------------------------
+  stale-reviewer-issues:
+    name: "Issues – nudge reviewer"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Only process issues waiting on a reviewer
+          only-issue-labels: "awaiting-reviewer"
+
+          # 15 days with no reviewer activity → mark stale-reviewer
+          days-before-issue-stale: 15
+          # Never auto-close (reviewer staleness is a soft nudge, not a hard close)
+          days-before-issue-close: -1
+
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          stale-issue-label: "stale-reviewer"
+          labels-to-remove-when-unstale: "stale-reviewer"
+
+          stale-issue-message: |
+            This issue has had recent activity from the contributor but no
+            reviewer response in **15 days**. A reviewer's attention is needed
+            to keep this moving forward @assignee.
+
+            > _Automated message from the stale-reviewer workflow._
+
+          exempt-issue-labels: "awaiting-contributor"
+          exempt-all-issue-milestones: true
+
+          operations-per-run: 150
+          ascending: true
+
+  # ----------------------------------------------------------
+  # JOB 3 – Scheduled: nudge overdue reviewers on PRs
+  # ----------------------------------------------------------
+  stale-reviewer-prs:
+    name: "PRs – nudge reviewer"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          only-pr-labels: "awaiting-reviewer"
+
+          days-before-pr-stale: 15
+          days-before-pr-close: -1   # never auto-close on reviewer staleness
+
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          stale-pr-label: "stale-reviewer"
+          labels-to-remove-when-unstale: "stale-reviewer"
+
+          stale-pr-message: |
+            This PR has had recent activity from the contributor but no reviewer
+            response in **15 days**. A review is needed to unblock progress @assignee.
+
+            > _Automated message from the stale-reviewer workflow._
+
+          exempt-pr-labels: "awaiting-contributor"
+          exempt-all-pr-milestones: true
+          exempt-draft-pr: true
+
+          operations-per-run: 150
+          ascending: true


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate the management of stale issues and pull requests based on contributor and reviewer activity. These workflows help keep the repository organized by labeling and, when appropriate, closing items that have not received timely responses. The main changes are:

**Contributor inactivity automation**  
* Adds `.github/workflows/stale-contrib.yml` to automatically warn contributors after 30 days of inactivity following reviewer feedback, and closes issues/PRs after 7 additional days if there is still no response. 

**Reviewer inactivity automation**  
* Adds `.github/workflows/stale-reviewer.yml` to nudge reviewers if they have not responded within 15 days after a contributor's update. This workflow labels such items as `stale-reviewer` but does not auto-close them.
* Implements real-time label routing in `stale-reviewer.yml` to automatically switch between `awaiting-contributor` and `awaiting-reviewer` labels based on who comments or reviews.

**Labeling and exemption logic**  
* Both workflows use a label contract (`awaiting-contributor`, `awaiting-reviewer`, `stale-contributor`, `stale-reviewer`, etc.) and support exemptions for items with specific labels or milestones, as well as draft PRs. 