### PR TITLE
ref(rh850): configure arch_init as weak

### DIFF
--- a/src/arch/rh850/init.c
+++ b/src/arch/rh850/init.c
@@ -15,7 +15,7 @@ static inline void ei()
     asm volatile("ei\n\t");
 }
 
-void arch_init()
+__attribute__((weak)) void arch_init()
 {
 #ifndef SINGLE_CORE
     if (cpu_is_master()) {


### PR DESCRIPTION
This PR marks the `arch_init` function in the RH850 architecture as _weak_, aligning with the pattern used in other architectures and enabling it to be overridden for custom external configurations.