### PR TITLE
ref(rh850): allow for UART/Timer override

### DIFF
--- a/src/arch/tricore/timer.c
+++ b/src/arch/tricore/timer.c
@@ -58,7 +58,6 @@ void timer_disable()
     *ICR = 0x0;
 }
 
-
 uint64_t timer_get()
 {
     volatile unsigned long long* ABS = STM_ABS_ADDR;

--- a/src/platform/rh850-u2a16/inc/plat.h
+++ b/src/platform/rh850-u2a16/inc/plat.h
@@ -18,29 +18,39 @@
 
 /* --------------------------------------- */
 
-#define PLAT_CLK_RLIN       (80000000)     // 80 MHz
-#define PLAT_UART_ADDR      (0xFFC7C100)   // RLIN35 Base
-#define UART_IRQ_ID         (438)          // RLIN35 Receive completion interrupt
+#define PLAT_CLK_RLIN       (80000000) // 80 MHz
 
-#define PLAT_OSTM0_BASE     (0xFFBF0000UL) // OSTM0
-// OSTM0 timer interrupt
-#define TIMER_IRQ_ID        (199UL)
+// Use RLIN35 by default
+#ifndef PLAT_UART_ADDR
+#define PLAT_UART_ADDR (0xFFC7C100)
+#endif
+#ifndef UART_IRQ_ID
+#define UART_IRQ_ID (438)
+#endif
 
-#define PLAT_INTC1_BASE     (0xFFFC0000UL)
-#define PLAT_INTC2_BASE     (0xFFF80000UL)
-#define PLAT_INTIF_BASE     (0xFF090000UL)
-#define PLAT_EINTS_BASE     (0xFFC00000UL)
-#define PLAT_FENC_BASE      (0xFF9A3A00UL)
-#define PLAT_FEINC_BASE     (0xFF9A3B00UL)
-#define PLAT_IPIR_BASE      (0xFFFB9000UL)
+// Use OSTM0 by default
+#ifndef PLAT_OSTM_BASE
+#define PLAT_OSTM_BASE (0xFFBF0000UL)
+#endif
+#ifndef TIMER_IRQ_ID
+#define TIMER_IRQ_ID (199UL)
+#endif
 
-#define PLAT_BOOTCTRL_ADDR  (0xFFFB2000UL)
+#define PLAT_INTC1_BASE    (0xFFFC0000UL)
+#define PLAT_INTC2_BASE    (0xFFF80000UL)
+#define PLAT_INTIF_BASE    (0xFF090000UL)
+#define PLAT_EINTS_BASE    (0xFFC00000UL)
+#define PLAT_FENC_BASE     (0xFF9A3A00UL)
+#define PLAT_FEINC_BASE    (0xFF9A3B00UL)
+#define PLAT_IPIR_BASE     (0xFFFB9000UL)
 
-#define PLAT_CLK_HSB        (80000000UL)
+#define PLAT_BOOTCTRL_ADDR (0xFFFB2000UL)
+
+#define PLAT_CLK_HSB       (80000000UL)
 
 // OSTM use CLK_HSB
-#define TIMER_FREQ          PLAT_CLK_HSB
+#define TIMER_FREQ         PLAT_CLK_HSB
 
-#define PLAT_CPU_FREQ       (400000000UL) // 400 MHz. This value depends on CKDIVMD OPTION BYTE.
+#define PLAT_CPU_FREQ      (400000000UL) // 400 MHz. This value depends on CKDIVMD OPTION BYTE.
 
 #endif

--- a/src/platform/rh850-u2a16/u2a16.c
+++ b/src/platform/rh850-u2a16/u2a16.c
@@ -10,7 +10,7 @@
 
 static volatile struct renesas_rlin3* uart = (void*)PLAT_UART_ADDR;
 
-static volatile struct rh850_u2a16_OSTMn* timer = (void*)PLAT_OSTM0_BASE;
+static volatile struct rh850_u2a16_OSTMn* timer = (void*)PLAT_OSTM_BASE;
 
 void uart_init()
 {


### PR DESCRIPTION
Current RH850 support assumes RLIN35 and OSTM0 as the platform UART and timer, respectively.

Since RH850-based platforms may use different UARTs and OSTM channels, this PR allows overriding `PLAT_UART_ADDR`, `UART_IRQ_ID`, `PLAT_OSTM_BASE`, and `TIMER_IRQ_ID` platform definitions without requiring modifications to platform description files.