### PR TITLE
fix(irq): add save and restore lower context

### DIFF
--- a/src/arch/tricore/inc/arch/cycle_counter.h
+++ b/src/arch/tricore/inc/arch/cycle_counter.h
@@ -23,10 +23,7 @@ static inline void arch_cc_stop(void)
     csfr_cctrl_write(0);
 }
 
-static inline void arch_cc_enable(void)
-{
-    NOT_IMPLEMENTED();
-}
+static inline void arch_cc_enable(void) { }
 
 static inline void arch_cc_reset_count(void)
 {

--- a/src/arch/tricore/start.S
+++ b/src/arch/tricore/start.S
@@ -247,7 +247,9 @@ non_mskbl_interrupt:
 _irq_vector:
    .rept  254
         .balign 32
+            svlcx
             call ir_handle
+            rslcx
             rfe
         1:
             j 1b


### PR DESCRIPTION
For most cases, saving and restoring the lower context is not needed. However, sometimes the compiler can use register that are not saved/restored otherwise, corrupting the non-irq code.

Also removed a blocking macro in the cycle counter code. 