### PR TITLE
feat(plat): add SpacemiT K3 CoM260 support

### DIFF
--- a/src/drivers/8250_uart/8250_uart.c
+++ b/src/drivers/8250_uart/8250_uart.c
@@ -6,13 +6,14 @@
 // #include <sbi/riscv_io.h>
 // #include <sbi_utils/serial/uart8250.h>
 #include <8250_uart.h>
+#include <plat.h>
 
 #define readb(addr)       (*((volatile uint8_t*)addr))
 #define writeb(val, addr) (*(volatile uint8_t*)(addr) = val)
 #define readw(addr)       (*((volatile uint16_t*)addr))
 #define writew(val, addr) (*(volatile uint16_t*)(addr) = val)
-#define readl(addr)       (*((volatile uint32_t*)addr))
-#define writel(val, addr) (*((volatile uint32_t*)addr) = val)
+#define readl(addr)       (*((volatile uint32_t*)(addr)))
+#define writel(val, addr) (*((volatile uint32_t*)(addr)) = val)
 
 /* clang-format off */
 
@@ -39,6 +40,16 @@
 #define UART_LSR_OE		0x02    /* Overrun error indicator */
 #define UART_LSR_DR		0x01    /* Receiver data ready */
 #define UART_LSR_BRK_ERROR_BITS	0x1E    /* BI, FE, PE, OE bits */
+
+#define UART_IER_ERBFI		0x01    /* Enable received data available interrupt */
+#define UART_IER_RTOIE		0x10    /* XScale: receiver time out interrupt enable */
+#define UART_IER_UUE		0x40    /* XScale: UART unit enable */
+
+#define UART_FCR_EN		0x01    /* Enable FIFOs */
+#define UART_FCR_RX_CLR		0x02    /* Clear receive FIFO */
+#define UART_FCR_TX_CLR		0x04    /* Clear transmit FIFO */
+
+#define UART_MCR_OUT2		0x08    /* OUT2: gates the INTR output buffer */
 
 /* clang-format on */
 
@@ -97,7 +108,13 @@ void uart8250_interrupt_handler()
 
 void uart8250_enable_rx_int()
 {
-    set_reg(UART_IER_OFFSET, 1);
+#ifdef UART8250_XSCALE
+    /* RTOIE must also be set so received data below the FIFO trigger level
+     * (re)raises the interrupt after a character timeout. */
+    set_reg(UART_IER_OFFSET, UART_IER_UUE | UART_IER_RTOIE | UART_IER_ERBFI);
+#else
+    set_reg(UART_IER_OFFSET, UART_IER_ERBFI);
+#endif
 }
 
 int uart8250_init(unsigned long base, u32 in_freq, u32 baudrate, u32 reg_shift, u32 reg_width)
@@ -113,19 +130,29 @@ int uart8250_init(unsigned long base, u32 in_freq, u32 baudrate, u32 reg_shift, 
     bdiv = uart8250_in_freq / (16 * uart8250_baudrate);
 
     /* Disable all interrupts */
+#ifdef UART8250_XSCALE
+    /* XScale/PXA-style ports gate the whole UART on the IER Unit Enable (UUE)
+     * bit, so keep it set while masking all interrupt sources. */
+    set_reg(UART_IER_OFFSET, UART_IER_UUE);
+#else
     set_reg(UART_IER_OFFSET, 0x00);
+#endif
     /* Enable DLAB */
-    set_reg(UART_LCR_OFFSET, 0x80);
+    set_reg(UART_LCR_OFFSET, 0x0);
     // /* Set divisor low byte */
     // set_reg(UART_DLL_OFFSET, bdiv & 0xff);
     // /* Set divisor high byte */
     // set_reg(UART_DLM_OFFSET, (bdiv >> 8) & 0xff);
     /* 8 bits, no parity, one stop bit */
     set_reg(UART_LCR_OFFSET, 0x03);
-    /* Enable FIFO */
-    set_reg(UART_FCR_OFFSET, 0x01);
-    /* No modem control DTR RTS */
-    set_reg(UART_MCR_OFFSET, 0x00);
+    /* Enable and clear FIFOs */
+    set_reg(UART_FCR_OFFSET, UART_FCR_EN | UART_FCR_RX_CLR | UART_FCR_TX_CLR);
+    /* MCR: raise OUT2. On a 16550 OUT2 gates the tri-state INTR output buffer -
+     * with OUT2=0 the RX interrupt is raised internally (IIR pending, LSR.DR=1)
+     * but never reaches the external INTR pin. Linux does this in
+     * serial8250_init_mctrl ("Most PC uarts need OUT2 raised to enable
+     * interrupts"). DTR/RTS left low. */
+    set_reg(UART_MCR_OFFSET, UART_MCR_OUT2);
     /* Clear line status */
     get_reg(UART_LSR_OFFSET);
     /* Read receive buffer */

--- a/src/platform/k3-com260/inc/plat.h
+++ b/src/platform/k3-com260/inc/plat.h
@@ -1,0 +1,84 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef PLAT_H
+#define PLAT_H
+
+/*
+ * SpacemiT K3 baremetal guest, as seen from inside the Bao VM.
+ *
+ * These values describe the VIRTUAL platform that Bao presents to this guest
+ * and MUST stay consistent with the VM entry in the hypervisor configuration
+ * (configs/k3-com260/config.c):
+ *
+ *   PLAT_MEM_BASE / PLAT_MEM_SIZE  <- vm_config.platform.regions[0]
+ *   PLAT_UART_ADDR / UART_IRQ_ID   <- vm_config.platform.devs[0] (UART0 passthrough)
+ *   PLAT_APLIC_CTL_BASE_ADDR       <- vm_config.platform.arch.irqc.aia.aplic.base
+ *   PLAT_IMSIC_IF_BASE_ADDR        <- vm_config.platform.arch.irqc.aia.imsic.base
+ */
+
+/* Guest RAM. This is guest-physical; Bao maps it onto real K3 DRAM. */
+#define PLAT_MEM_BASE   0x102000000
+#define PLAT_MEM_SIZE   0x4000000
+
+/* K3 generic timer / CLINT timebase-frequency = 24 MHz. */
+#define PLAT_TIMER_FREQ (24000000ull)
+
+/* K3 UART passed through to the guest (spacemit,k1-uart / intel,xscale-uart).
+ * Registers are 32-bit and 4 bytes apart (reg-shift=2, reg-io-width=4); that is
+ * handled in spacemit_k3.c via the 8250 driver init arguments.
+ *
+ * Defaults to UART0 (0xd4017000, wired source 42). Overridable at build time so
+ * a guest can be given a different K3 UART, e.g. the linux+baremetal demo runs
+ * this guest on UART4 (-DPLAT_UART_ADDR=0xd4017300 -DUART_IRQ_ID=46) to keep its
+ * console separate from the Linux guest on UART0. */
+#ifndef PLAT_UART_ADDR
+#define PLAT_UART_ADDR (0xd4017000)
+#endif
+#ifndef UART_IRQ_ID
+#define UART_IRQ_ID (42)
+#endif
+/* XScale/PXA-style port: the 8250 driver must keep the IER Unit Enable (UUE)
+ * bit set and use the receiver time-out interrupt. */
+#define UART8250_XSCALE           (1)
+
+/* AIA controllers. These addresses are the physical S-level controllers, which
+ * Bao also mirrors as the guest-visible bases. */
+#define PLAT_APLIC_CTL_BASE_ADDR  (0xe0804000)
+#define PLAT_APLIC_MAX_INTERRUPTS (512)
+#define PLAT_IMSIC_IF_BASE_ADDR   (0xe0400000)
+/* Must be >= PLAT_APLIC_MAX_INTERRUPTS and > IPI_IRQ_ID. */
+#define PLAT_IMSIC_MAX_INTERRUPTS (512)
+
+/*
+ * Bao gives this guest a VS-level IMSIC interrupt file, and on the K3 a VS-file
+ * supports only 63 MSI ids (the S-file supports 511). So every eiid the guest
+ * uses MUST be <= 63: the wired UART is source 42 (ok), but the default AIA
+ * IPI_IRQ_ID of 255 is out of range and its seteipnum/EIE writes are dropped by
+ * the VS-file -> IPIs never deliver. Use the top valid VS-file id (63), which
+ * does not collide with the UART (42).
+ * (Standalone on real silicon uses the S-file (511 ids); there 255 is fine, so a
+ * bare-metal-on-hardware build can leave IPI_IRQ_ID at its 255 default.)
+ */
+#define IPI_IRQ_ID                (63)
+
+/*
+ * Per-vCPU stride between S-mode IMSIC interrupt files = 2^guest-index-bits pages.
+ * This plat.h describes the BAO-VIRTUAL platform, and Bao maps each vCPU's IMSIC
+ * file CONTIGUOUSLY, one page apart (vimsic.c: imsic.base + PAGE_SIZE*vcpu_id), so
+ * the guest must use a 1-page stride => guest-index-bits = 0.
+ *
+ * (On REAL silicon the K3 S-IMSIC has riscv,guest-index-bits = 6, i.e. a 0x40000
+ * per-hart stride. For a standalone-on-hardware build, override this with
+ * -DPLAT_IMSIC_GUEST_INDEX_BITS=6.)
+ */
+#ifndef PLAT_IMSIC_GUEST_INDEX_BITS
+#define PLAT_IMSIC_GUEST_INDEX_BITS (0)
+#endif
+
+/* The X100 harts implement Sstc. */
+#define CPU_EXT_SSTC 1
+
+#endif

--- a/src/platform/k3-com260/k3_com260.c
+++ b/src/platform/k3-com260/k3_com260.c
@@ -1,0 +1,115 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <plat.h>
+
+/*
+ * Two console back-ends, picked at build time:
+ *
+ *   default            - drive the K3 UART (8250-compatible) directly. The guest
+ *                        must own the UART (passthrough) and its RX IRQ.
+ *
+ *   -DCONSOLE_VIA_SBI  - print/read through the SBI legacy console (ecall EID
+ *                        0x01/0x02). The guest needs no UART at all; its ecall
+ *                        traps to the hypervisor. NOTE: this only produces output
+ *                        if the hypervisor forwards the legacy console extension
+ *                        to its own SBI (Bao does NOT do this out of the box - its
+ *                        sbi_vs_handler only implements BASE/TIME/IPI/RFNC/HSM).
+ *                        Legacy SBI has no RX interrupt, so getchar is polling and
+ *                        the RX-IRQ hooks are no-ops.
+ */
+
+#if defined(CONSOLE_VIA_SBI)
+
+#include <sbi.h>
+
+void uart_init()
+{
+    /* The console UART is owned and already configured by OpenSBI. */
+}
+
+void uart_putc(char c)
+{
+    sbi_console_putchar((int)c);
+}
+
+char uart_getchar(void)
+{
+    return (char)sbi_console_getchar();
+}
+
+void uart_enable_rxirq()
+{
+    /* Legacy SBI console delivers no RX interrupt; nothing to enable. */
+}
+
+void uart_clear_rxirq() { }
+
+#else /* direct UART */
+
+#include <8250_uart.h>
+
+#define K3_UART_ADDR      (PLAT_UART_ADDR)
+#define K3_UART_BAUDRATE  (115200)
+
+/*
+ * The K3 UART exposes 16550-compatible registers that are 32-bit wide and
+ * spaced 4 bytes apart (device tree: reg-shift = <2>, reg-io-width = <4>).
+ *
+ * The 8250 driver does not reprogram the baud divisor (those writes are disabled
+ * in 8250_uart.c), since OpenSBI/U-Boot have already configured the line. The
+ * input clock value is therefore only used to compute an unused divisor and can
+ * be any sane number.
+ */
+#define K3_UART_IN_FREQ   (14745600)
+#define K3_UART_REG_SHIFT (2)
+#define K3_UART_REG_WIDTH (4)
+
+void uart_init()
+{
+    /* OpenSBI/U-Boot already enabled the UART0 clocks and brought it out of reset
+     * (TX works), so the guest does NOT touch the SoC clock controller (syscon_apbc
+     * @0xd4015000) - under Bao that region isn't passed through and the access would
+     * trap. Just program the line. */
+    uart8250_init(K3_UART_ADDR, K3_UART_IN_FREQ, K3_UART_BAUDRATE, K3_UART_REG_SHIFT,
+        K3_UART_REG_WIDTH);
+}
+
+void uart_putc(char c)
+{
+    uart8250_putc(c);
+}
+
+char uart_getchar(void)
+{
+    return uart8250_getc();
+}
+
+void uart_enable_rxirq()
+{
+    uart8250_enable_rx_int();
+}
+
+void uart_clear_rxirq()
+{
+    uart8250_interrupt_handler();
+}
+
+#endif /* CONSOLE_VIA_SBI */
+
+#include <aplic.h>
+
+/*
+ * Per-irq sense for the K3 (overrides the weak edge-rising default in the AIA
+ * irqc): the wired UART line is active-high level, not edge. Everything else
+ * keeps the edge-rising default.
+ */
+uint32_t irqc_get_irq_sense(unsigned long int_id)
+{
+    if (int_id == UART_IRQ_ID) {
+        return APLIC_SOURCECFG_SM_LEVEL_HIGH;
+    }
+    return APLIC_SOURCECFG_SM_EDGE_RISE;
+}

--- a/src/platform/k3-com260/plat.mk
+++ b/src/platform/k3-com260/plat.mk
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+# SpacemiT K3 baremetal guest, running as a Bao VM.
+#
+# The addresses below are the GUEST-VISIBLE addresses, which must match the
+# corresponding VM definition in the Bao hypervisor configuration:
+#   - PLAT_UART_ADDR is the UART0 device passed through to this VM.
+#   - The virtual AIA (APLIC + IMSIC) base addresses match
+#     vm_config.platform.arch.irqc.aia.{aplic,imsic}.base.
+
+ARCH:=riscv
+drivers:=8250_uart
+IRQC:=AIA

--- a/src/platform/k3-com260/sources.mk
+++ b/src/platform/k3-com260/sources.mk
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+plat_c_srcs:=k3_com260.c
+plat_s_srcs:=


### PR DESCRIPTION
Add a bare-metal guest port for the SpacemiT K3 (CoM260 Kit) running as a Bao VM, along with XScale/PXA-style 16550 UART support in the 8250 driver.

Depends on https://github.com/bao-project/bao-baremetal-guest/pull/41 and https://github.com/bao-project/bao-baremetal-guest/pull/42.