### PR TITLE
Add BeagleBone AI-64 (TDA4VM - J721E) platform support

### DIFF
--- a/src/platform/beaglebone-ai64/beaglebone-ai64.c
+++ b/src/platform/beaglebone-ai64/beaglebone-ai64.c
@@ -1,0 +1,26 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <8250_uart.h>
+#include <plat.h>
+
+#define BBAI64_UART_ADDR (PLAT_UART_ADDR)
+#define BBAI64_UART_BAUDRATE (115200)
+#define BBAI64_UART_IN_FREQ (48000000)
+#define BBAI64_UART_REG_SHIFT (2)
+#define BBAI64_UART_REG_WIDTH (4)
+
+void uart_init(void) {
+  uart8250_init(BBAI64_UART_ADDR, BBAI64_UART_IN_FREQ, BBAI64_UART_BAUDRATE,
+                BBAI64_UART_REG_SHIFT, BBAI64_UART_REG_WIDTH);
+}
+
+void uart_putc(char c) { uart8250_putc(c); }
+
+char uart_getchar(void) { return uart8250_getc(); }
+
+void uart_enable_rxirq(void) { uart8250_enable_rx_int(); }
+
+void uart_clear_rxirq(void) { uart8250_interrupt_handler(); }

--- a/src/platform/beaglebone-ai64/inc/plat.h
+++ b/src/platform/beaglebone-ai64/inc/plat.h
@@ -1,0 +1,24 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef PLAT_H
+#define PLAT_H
+
+#define PLAT_MEM_BASE 0x80000000
+#define PLAT_MEM_SIZE 0x8000000
+
+#define PLAT_GICD_BASE_ADDR (0x01800000)
+#define PLAT_GICC_BASE_ADDR (0x01810000)
+#define PLAT_GICR_BASE_ADDR (0x01900000)
+
+#ifndef PLAT_UART_ADDR
+#define PLAT_UART_ADDR (0x02800000)
+#endif
+
+#ifndef UART_IRQ_ID
+#define UART_IRQ_ID (224) /* GIC SPI 192 + 32 (SPI offset) = 224 */
+#endif
+
+#endif /* PLAT_H */

--- a/src/platform/beaglebone-ai64/plat.mk
+++ b/src/platform/beaglebone-ai64/plat.mk
@@ -1,0 +1,6 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+ARCH:=armv8
+GIC_VERSION:=GICV3
+drivers:=8250_uart

--- a/src/platform/beaglebone-ai64/sources.mk
+++ b/src/platform/beaglebone-ai64/sources.mk
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+plat_c_srcs:=beaglebone-ai64.c
+plat_s_srcs:=


### PR DESCRIPTION
This PR introduces support for the BeagleBone AI-64 platform, featuring TI's TDA4VM SoC with the K3 (keystone3) architecture.