### PR TITLE
fix(e3650): change cpu freq

### DIFF
--- a/src/platform/e3650/inc/plat.h
+++ b/src/platform/e3650/inc/plat.h
@@ -6,16 +6,18 @@
 #ifndef __PLAT_H__
 #define __PLAT_H__
 
-#define PLAT_MEM_BASE                 (0x00B00000)
-#define PLAT_MEM_SIZE                 (0x00100000)
+#define PLAT_MEM_BASE       (0x00B00000)
+#define PLAT_MEM_SIZE       (0x00100000)
 
-#define PLAT_GICD_BASE_ADDR           (0xF4000000)
-#define PLAT_GICC_BASE_ADDR           (0xF4200000)
-#define PLAT_GICR_BASE_ADDR           (0xF4100000)
+#define PLAT_GICD_BASE_ADDR (0xF4000000)
+#define PLAT_GICC_BASE_ADDR (0xF4200000)
+#define PLAT_GICR_BASE_ADDR (0xF4100000)
 
-#define PLAT_GENERIC_TIMER_FIXED_FREQ (600000000)
+#ifndef PLAT_GENERIC_TIMER_FIXED_FREQ
+#define PLAT_GENERIC_TIMER_FIXED_FREQ (6000000UL) // 6MHz
+#endif
 
-#define PLAT_UART_ADDR                (0xF8D60000)
-#define UART_IRQ_ID                   (114)
+#define PLAT_UART_ADDR (0xF8D60000)
+#define UART_IRQ_ID    (114)
 
 #endif /* __PLAT_H__ */


### PR DESCRIPTION
This pull request makes a small change to the definition of the `PLAT_GENERIC_TIMER_FIXED_FREQ` macro in `plat.h`. The macro is now only defined if it hasn't been defined previously, and its value has been updated to `6000000UL` (6 MHz).